### PR TITLE
More efficient docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM rust:1.46 as builder
 WORKDIR /usr/src/kpm
-COPY . .
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir -p src; echo 'fn main() {}' > src/main.rs && cargo build --release && rm -rf src
+
+COPY src src
 RUN cargo install --path .
 
 FROM debian:buster-slim


### PR DESCRIPTION
Don't just copy everything in . into the docker, but instead first just build the dependencies and then only copy src.