### PR TITLE
Toggle usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,6 +946,7 @@ dependencies = [
  "async-std",
  "httpdate",
  "md5",
+ "serde",
  "surf",
  "tera",
  "tide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ tide-tera = "0.2.0"
 md5 = "0.7.0"
 httpdate = "0.3.1"
 surf = { version = "2.0.0", default-features = false, features = ["h1-client"] }
+serde = { version = "1.0.0", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ impl State {
 
 async fn start_page(req: Request<State>) -> Result<Response, tide::Error> {
     let kpm = req.state();
-    let is_active = dbg!(req.cookie("use_kpm")).is_some();
+    let is_active = req.cookie("use_kpm").is_some();
     kpm.tera.render_response(
         "index.html",
         &context! {
@@ -86,7 +86,7 @@ async fn start_page(req: Request<State>) -> Result<Response, tide::Error> {
 async fn enable_or_disable(mut req: Request<State>) -> Result<Response, tide::Error> {
     let post: StatusForm = req.body_form().await?;
     let kpm = req.state();
-    let activate = dbg!(post).action == "enable";
+    let activate = post.action == "enable";
     if activate {
         tide::log::info!("A user activated KPM");
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
 use async_std::process::exit;
 use httpdate::fmt_http_date;
+use serde::Deserialize;
 use std::env;
 use std::time::{Duration, SystemTime};
 use tera::Tera;
-use tide::http::headers::EXPIRES;
+use tide::http::headers::{EXPIRES, LOCATION, SET_COOKIE};
 use tide::http::mime;
 use tide::{Request, Response};
 use tide_tera::prelude::*;
@@ -15,7 +16,7 @@ type Error = Box<dyn std::error::Error + Send + Sync>;
 
 /// The main entry point.
 ///
-/// This just initalizies the loggr, calls run and logs when it returns.
+/// This just initalizies the logger, calls run and logs when it returns.
 #[async_std::main]
 async fn main() {
     tide::log::start();
@@ -38,6 +39,7 @@ async fn run() -> Result<(), Error> {
     let mut app = tide::with_state(State::new()?);
 
     app.at("/kpm/").get(start_page);
+    app.at("/kpm/").post(enable_or_disable);
     app.at("/kpm/index.js").get(index_js);
     app.at(&format!("/kpm/{}", css::page_css_name()))
         .get(page_css);
@@ -62,17 +64,50 @@ impl State {
         let footer = footer::Footer::new();
         Ok(State { tera, footer })
     }
+    fn base_url(&self) -> String {
+        let host_url = env_or("SERVER_HOST_URL", "http://localdev.kth.se:8080");
+        format!("{}/kpm/", host_url)
+    }
 }
 
 async fn start_page(req: Request<State>) -> Result<Response, tide::Error> {
     let kpm = req.state();
+    let is_active = dbg!(req.cookie("use_kpm")).is_some();
     kpm.tera.render_response(
         "index.html",
         &context! {
+            "is_active" => is_active,
             "page_css" => css::page_css_name(),
             "kth_footer" => *kpm.footer.get().await,
         },
     )
+}
+
+async fn enable_or_disable(mut req: Request<State>) -> Result<Response, tide::Error> {
+    let post: StatusForm = req.body_form().await?;
+    let kpm = req.state();
+    let activate = dbg!(post).action == "enable";
+    if activate {
+        tide::log::info!("A user activated KPM");
+    } else {
+        tide::log::info!("A user disabled KPM");
+    }
+    Ok(Response::builder(302)
+        .header(LOCATION, kpm.base_url())
+        .header(
+            SET_COOKIE,
+            if activate {
+                "use_kpm=t; Domain=.kth.se; Path=/; HttpOnly"
+            } else {
+                "use_kpm=; Max-Age=0; Domain=.kth.se; Path=/; HttpOnly"
+            },
+        )
+        .build())
+}
+
+#[derive(Debug, Deserialize)]
+struct StatusForm {
+    action: String,
 }
 
 async fn monitor(_req: Request<State>) -> Result<Response, tide::Error> {
@@ -87,11 +122,12 @@ async fn monitor(_req: Request<State>) -> Result<Response, tide::Error> {
 
 async fn index_js(req: Request<State>) -> Result<Response, tide::Error> {
     let kpm = req.state();
-    let host_url = env_or("SERVER_HOST_URL", "http://localdev.kth.se:8080");
+    let base_url = kpm.base_url();
     kpm.tera.render_response(
         "index.js",
         &context! {
-            "css_url" => format!("{}/kpm/{}", host_url, css::menu_css_name()),
+            "css_url" => format!("{}{}", base_url, css::menu_css_name()),
+            "kpm_base" => base_url,
         },
     )
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,8 +35,9 @@
     <div id="gradientBorder"></div>
   </header>
   <div class="container main">
-    <div class="row"><div class="col">
-        <main style="padding-top: 1em">
+    <div class="row">
+      <div class="col" style="flex-basis: 27em; padding-top: 1em">
+        <main>
           <header role="presentation" id="articleHeader" class="mb-4">
             <h1 id="page-heading" class="mb-0" aria-labelledby="page-heading page-sub-heading">KTH Personal Menu</h1>
             <p id="page-sub-heading" class="t4 mt-1" aria-hidden="true">
@@ -47,7 +48,7 @@
             <p>The personal menu has been around at KTH for a long time.
               Now is the time to make a new start and try to make it better.</p>
 
-            <p>Currently, this new start is pretty much a blank canvas.
+            <p>Currently, this new start is pretty much a blank slate.
               It is up to us in the kpm development team to make it
               work, but it is up to <em>you</em>, the student, faculty,
               or staff at KTH to tell us what it should contain.</p>
@@ -57,7 +58,32 @@
               are important to include in the new menu?</p>
           </div>
         </main>
-    </div></div>
+      </div>
+      <div class="col" style="flex-basis: 18em; flex-grow: .5; padding-top: 2.5em;">
+        <h2>Toggle <abbr title="KTH Personal Menu">KPM</abbr></h2>
+        <form method="post" action="/kpm/">
+          {% if is_active %}
+          <p>You are currently using the experimental KPM.</p>
+          <p>If you disable KPM, pages other than this will show the
+            stable personal menu.</p>
+          <p>
+            <input type="hidden" name="action" value="disable"/>
+            <button type="submit" class="btn btn-primary">Disable experimental
+              KPM</button></p>
+          {% else %}
+          <p>You are currently using the stable personal menu.</p>
+          <p>You can look at KPM on this page, or enable it to
+            replace the stable personal menu on all pages.</p>
+          <p>If you activate KPM, there is a link back here in it, so
+            you can turn it back off.</p>
+          <p>
+            <input type="hidden" name="action" value="enable"/>
+            <button type="submit" class="btn btn-success">Enable experimental
+              KPM</button></p>
+          {% endif %}
+        </form>
+      </div>
+    </div>
   </div>
   <footer class="container">{{ kth_footer | safe }}</footer>
 </body>

--- a/templates/index.js
+++ b/templates/index.js
@@ -20,7 +20,7 @@
     console.log("Open panel for", e.target)
     kpm.classList.toggle('open')
     // TODO: Load this from the server
-    kpm.querySelector('.kpmpanel').innerHTML = '<p>Hello world</p>'
+    kpm.querySelector('.kpmpanel').innerHTML = '<p>Hello world</p><p><a href="{{kpm_base}}">About KTH Personal Menu</a> – here you can enable or disable the new personal menu.</p>'
     e.preventDefault();
     e.stopPropagation();
   }


### PR DESCRIPTION
Add a button to enable/disable KPM.

With the button there is some text about the current state and how to get back. The actual setting/removal of a cookie is done by a POST request to the server, so that the server can log the change.

(Done: This PR is built on top of #6 , which should be merged before this is considered.)