### PR TITLE
Add version info to _monitor.

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,7 +61,7 @@ app.use('/kpm/dist', express.static('dist'))
 
 app.get('/kpm/_monitor', (req, res) => {
   res.setHeader('Content-Type', 'text/plain')
-  version = 'unknown'
+  let version = 'unknown'
   try {
     const info = require('./buildinfo.js')
     version = `${info.dockerName}-${info.dockerVersion} (${info.gitBranch})`

--- a/app.js
+++ b/app.js
@@ -61,7 +61,14 @@ app.use('/kpm/dist', express.static('dist'))
 
 app.get('/kpm/_monitor', (req, res) => {
   res.setHeader('Content-Type', 'text/plain')
-  res.send('APPLICATION_STATUS: OK')
+  version = 'unknown'
+  try {
+    const info = require('./buildinfo.js')
+    version = `${info.dockerName}-${info.dockerVersion} (${info.gitBranch})`
+  } catch(err) {
+    log.warn(`Failed to get app version: ${err}`)
+  }
+  res.send(`APPLICATION_STATUS: OK ${version}`)
 })
 
 app.get(`/kpm/${menuCssName}`, (req, res) => {


### PR DESCRIPTION
Add version (from evolene version file) to `_monitor` output.  Will be "unknown" in local development, but the correct information for an actual build.

Q: Should we use a global `const version` to avoid loading the `./buildinfo.js` on each request?  Or do we have more than enough global consts as it is?  Maybe a node `require` has good enough caching anyway?