### PR TITLE
"isDev" to be true when is NOT production

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -19,7 +19,7 @@ const express = require("express");
 const authenticationMiddleware = require("./middleware/authenticationMiddleware.js");
 const app = express();
 
-const isDev = process.env.NODE_ENV === "production";
+const isDev = process.env.NODE_ENV !== "production";
 
 const blocks = {
   title: "1.260060",
@@ -74,8 +74,8 @@ app.use(
     name: "kpm",
     secret: process.env.SESSION_SECRET,
     cookie: {
-      secure: isDev,
-      httpOnly: isDev,
+      secure: !isDev,
+      httpOnly: !isDev,
       expires,
       domain: "kth.se",
     },


### PR DESCRIPTION
This PR fixes what I think is typo 😄 

I guess a variable called `isDev` should be `true` when in development mode, not the other way around