### PR TITLE
Don't use env in kpm.js

### DIFF
--- a/client/kpm.js
+++ b/client/kpm.js
@@ -1,9 +1,15 @@
+console.log("Starting kpm.js");
+
 import { intl, addLanguageSelector } from "./translation";
+
+console.log("Imported translation");
 
 // Note: src is the resolved url, not the raw attribute
 const scriptUrl = (
   document.currentScript || document.querySelector("script[src$='/kpm.js']")
 ).src;
+
+console.log("Script url is", scriptUrl);
 
 const kpm = document.createElement("nav");
 kpm.id = "kpm";
@@ -62,7 +68,9 @@ async function openMenu(event) {
 }
 
 async function fetchPanel(panel) {
-  const response = await window.fetch(new URL(`panels/${panel}`, scriptUrl));
+  url = new URL(`panels/${panel}`, scriptUrl);
+  console.log("Fetch panel", panel, "from", url);
+  const response = await window.fetch(url);
   if (response.status > 400) {
     console.error(`Error when fetching the "${panel}" panel: `, response);
   } else {

--- a/client/kpm.js
+++ b/client/kpm.js
@@ -51,9 +51,12 @@ async function create() {
   addLanguageSelector(recreate);
 
   const btn = document.getElementById("kpm-alert-btn");
-  btn.addEventListener("click", (e) => {
-    document.getElementById("kpm-alert").remove();
-  });
+
+  if (btn) {
+    btn.addEventListener("click", (e) => {
+      document.getElementById("kpm-alert").remove();
+    });
+  }
 
   await style;
 }

--- a/client/kpm.js
+++ b/client/kpm.js
@@ -78,7 +78,10 @@ async function openMenu(event) {
 async function fetchPanel(panel) {
   const url = new URL(`panels/${panel}`, scriptUrl);
   console.log("kpm: Fetch panel", panel, "from", url);
-  const response = await window.fetch(url, { credentials: "include" });
+  const response = await window.fetch(url, {
+    mode: "cors",
+    credentials: "include",
+  });
   if (response.status > 400) {
     console.error(`kpm: Error when fetching the "${panel}" panel: `, response);
   } else {

--- a/client/kpm.js
+++ b/client/kpm.js
@@ -1,15 +1,15 @@
-console.log("Starting kpm.js");
+console.log("kpm: Starting kpm.js");
 
 import { intl, addLanguageSelector } from "./translation";
 
-console.log("Imported translation");
+console.log("kpm: Imported translation");
 
 // Note: src is the resolved url, not the raw attribute
 const scriptUrl = (
   document.currentScript || document.querySelector("script[src$='/kpm.js']")
 ).src;
 
-console.log("Script url is", scriptUrl);
+console.log("kpm: Script url is", scriptUrl);
 
 const kpm = document.createElement("nav");
 kpm.id = "kpm";
@@ -23,7 +23,10 @@ function recreate() {
 }
 
 async function create() {
+  console.log("kpm: Load menu css");
   await import("./menu.css");
+  console.log("kpm: Loaded menu css");
+
   const content = await fetchPanel("");
   kpm.innerHTML = content;
 
@@ -69,10 +72,10 @@ async function openMenu(event) {
 
 async function fetchPanel(panel) {
   url = new URL(`panels/${panel}`, scriptUrl);
-  console.log("Fetch panel", panel, "from", url);
+  console.log("kpm: Fetch panel", panel, "from", url);
   const response = await window.fetch(url);
   if (response.status > 400) {
-    console.error(`Error when fetching the "${panel}" panel: `, response);
+    console.error(`kpm: Error when fetching the "${panel}" panel: `, response);
   } else {
     return await response.text();
   }

--- a/client/kpm.js
+++ b/client/kpm.js
@@ -24,7 +24,7 @@ function recreate() {
 
 async function create() {
   console.log("kpm: Load menu css");
-  await import("./menu.css");
+  import("./menu.css");
   console.log("kpm: Loaded menu css");
 
   const content = await fetchPanel("");

--- a/client/kpm.js
+++ b/client/kpm.js
@@ -24,8 +24,8 @@ function recreate() {
 
 async function create() {
   console.log("kpm: Load menu css");
-  import("./menu.css");
-  console.log("kpm: Loaded menu css");
+  const t = import("./menu.css");
+  console.log("kpm: Loaded menu css:", t);
 
   const content = await fetchPanel("");
   kpm.innerHTML = content;

--- a/client/kpm.js
+++ b/client/kpm.js
@@ -1,5 +1,10 @@
 import { intl, addLanguageSelector } from "./translation";
 
+// Note: src is the resolved url, not the raw attribute
+const scriptUrl = (
+  document.currentScript || document.querySelector("script[src$='/kpm.js']")
+).src;
+
 const kpm = document.createElement("nav");
 kpm.id = "kpm";
 kpm.innerHTML = `<div class="kpmbar">${intl("loading")}...</div>`;
@@ -57,9 +62,7 @@ async function openMenu(event) {
 }
 
 async function fetchPanel(panel) {
-  const response = await window.fetch(
-    `${process.env.SERVER_HOST_URL}/kpm/panels/${panel}`
-  );
+  const response = await window.fetch(new URL(`panels/${panel}`, scriptUrl));
   if (response.status > 400) {
     console.error(`Error when fetching the "${panel}" panel: `, response);
   } else {

--- a/client/kpm.js
+++ b/client/kpm.js
@@ -24,8 +24,8 @@ function recreate() {
 
 async function create() {
   console.log("kpm: Load menu css");
-  const t = import("./menu.css");
-  console.log("kpm: Loaded menu css:", t);
+  const style = import("./menu.css");
+  console.log("kpm: Loaded menu css:", style);
 
   const content = await fetchPanel("");
   kpm.innerHTML = content;
@@ -54,6 +54,8 @@ async function create() {
   btn.addEventListener("click", (e) => {
     document.getElementById("kpm-alert").remove();
   });
+
+  await style;
 }
 
 async function start() {

--- a/client/kpm.js
+++ b/client/kpm.js
@@ -78,7 +78,7 @@ async function openMenu(event) {
 async function fetchPanel(panel) {
   const url = new URL(`panels/${panel}`, scriptUrl);
   console.log("kpm: Fetch panel", panel, "from", url);
-  const response = await window.fetch(url);
+  const response = await window.fetch(url, { credentials: "include" });
   if (response.status > 400) {
     console.error(`kpm: Error when fetching the "${panel}" panel: `, response);
   } else {

--- a/client/kpm.js
+++ b/client/kpm.js
@@ -71,7 +71,7 @@ async function openMenu(event) {
 }
 
 async function fetchPanel(panel) {
-  url = new URL(`panels/${panel}`, scriptUrl);
+  const url = new URL(`panels/${panel}`, scriptUrl);
   console.log("kpm: Fetch panel", panel, "from", url);
   const response = await window.fetch(url);
   if (response.status > 400) {

--- a/client/menu.css
+++ b/client/menu.css
@@ -43,7 +43,15 @@ nav#kpm > .kpmbar a:focus {
 nav#kpm > .kpmpanel {
   border: solid 1px #006cb7;
   border-width: 0 1px 1ex 1px;
-  margin: -1px max(calc(50vw - 620px - 1em), 0px) 0;
+  /**
+  Why the second argument in "max" is "1px" instead of "0px":
+
+  Parcel converts the "0px" to "0"
+    So if we write this ---> "margin: -1px max(... 0px) 0"
+    it will be converted to  "margin: -1px max(... 0) 0"
+    and CSS will break because 0 is not a valid value for "max".
+  */
+  margin: -1px max(calc(50vw - 620px - 1em), 1px) 0;
   max-width: 50em;
   background: white;
   padding: 1em;

--- a/server/panels/router.js
+++ b/server/panels/router.js
@@ -50,6 +50,7 @@ panelsRouter.get("/hello", (req, res) => {
 function corsAllow(res, req) {
   res.header("Access-Control-Allow-Origin", req.headers["origin"] || "*");
   res.header("Access-Control-Allow-Credentials", "true");
+  res.header("Access-Control-Allow-Methods", "POST, GET, OPTIONS");
   //res.header("Access-Control-Allow-Headers", "X-Requested-With");
   res.header("Vary", "Origin");
 }

--- a/server/panels/router.js
+++ b/server/panels/router.js
@@ -15,6 +15,7 @@ const helloPanel = compileTemplate(__dirname, "hello.handlebars");
 // Returns the menu itself
 panelsRouter.get("/", (req, res) => {
   console.log(req.session.userId);
+  corsAllow(res, req);
   if (req.session.userId) {
     res.send(
       indexTemplate({
@@ -32,6 +33,7 @@ panelsRouter.get("/", (req, res) => {
 });
 
 panelsRouter.get("/hello", (req, res) => {
+  corsAllow(res, req);
   if (req.session.userId) {
     res.send(
       helloPanel({
@@ -44,3 +46,9 @@ panelsRouter.get("/hello", (req, res) => {
     res.send(errorPanel());
   }
 });
+
+function corsAllow(res, req) {
+  res.header("Access-Control-Allow-Origin", req.headers["origin"] || "*");
+  res.header("Access-Control-Allow-Credentials", "true");
+  res.header("Access-Control-Allow-Headers", "X-Requested-With");
+}

--- a/server/panels/router.js
+++ b/server/panels/router.js
@@ -50,5 +50,6 @@ panelsRouter.get("/hello", (req, res) => {
 function corsAllow(res, req) {
   res.header("Access-Control-Allow-Origin", req.headers["origin"] || "*");
   res.header("Access-Control-Allow-Credentials", "true");
-  res.header("Access-Control-Allow-Headers", "X-Requested-With");
+  //res.header("Access-Control-Allow-Headers", "X-Requested-With");
+  res.header("Vary", "Origin");
 }


### PR DESCRIPTION
Get the kpm base url from the relevant `script` tag instead of trying to evaluate a runtime environment variable in parcel.

There is still a problem with importing `menu.css`.  I have arranged things so that the menu works, but there is still an ugly stack trace in the console.   There is also a bunch of `consle.log("kpm: ...")` added. Most of them (if not all) should probably be removed later, but for now, until we get our fist 500 or so users, there's no harm in keeping them.