### PR TITLE
Implement a in-memory cache for Cortina blocks

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,9 +16,12 @@ server.listen(process.env.PORT || 3000, async () => {
   log.info(
     `Starting KPM at ${process.env.SERVER_HOST_URL}/kpm. Fetching Cortina blocks`
   );
-  await fetchCortinaBlock("footer");
-  await fetchCortinaBlock("megaMenu");
-  await fetchCortinaBlock("search");
+  await Promise.all([
+    renewCortinaBlock("footer"),
+    renewCortinaBlock("megaMenu"),
+    renewCortinaBlock("search"),
+  ]);
+  log.info("Cortina blocks ready");
 });
 
 setInterval(async function renewAllCortinaBlocks() {

--- a/app.js
+++ b/app.js
@@ -10,6 +10,19 @@ require("skog/bunyan").createLogger({
 require("@kth/reqvars").check();
 const server = require("./server/server");
 const log = require("skog");
-server.listen(process.env.PORT || 3000, () => {
-  log.info(`Starting KPM at ${process.env.SERVER_HOST_URL}/kpm`);
+const { renewCortinaBlock, fetchCortinaBlock } = require("./server/utils");
+
+server.listen(process.env.PORT || 3000, async () => {
+  log.info(
+    `Starting KPM at ${process.env.SERVER_HOST_URL}/kpm. Fetching Cortina blocks`
+  );
+  await fetchCortinaBlock("footer");
+  await fetchCortinaBlock("megaMenu");
+  await fetchCortinaBlock("search");
 });
+
+setInterval(async function renewAllCortinaBlocks() {
+  await renewCortinaBlock("footer");
+  await renewCortinaBlock("megaMenu");
+  await renewCortinaBlock("search");
+}, 62 * 62 * 1000);

--- a/server/server.js
+++ b/server/server.js
@@ -47,10 +47,10 @@ app.get("/kpm/logout", (req, res) => {
 });
 
 app.use("/kpm/panels", panelsRouter);
-app.get("/kpm", async (req, res) => {
-  const footer = await fetchCortinaBlock("footer");
-  const megaMenu = await fetchCortinaBlock("megaMenu");
-  const search = await fetchCortinaBlock("search");
+app.get("/kpm", (req, res) => {
+  const footer = fetchCortinaBlock("footer");
+  const megaMenu = fetchCortinaBlock("megaMenu");
+  const search = fetchCortinaBlock("search");
 
   res.send(
     infoPageTemplate({

--- a/server/server.js
+++ b/server/server.js
@@ -2,18 +2,9 @@ const session = require("express-session");
 const got = require("got");
 const loginRouter = require("./login-router");
 const panelsRouter = require("./panels/router");
-
-require("dotenv").config();
-require("skog/bunyan").createLogger({
-  app: "kpm",
-  name: "kpm",
-  level: "info",
-  serializers: require("bunyan").stdSerializers,
-});
 const log = require("skog");
 const express = require("express");
-const { compileTemplate } = require("./utils");
-
+const { compileTemplate, fetchCortinaBlock } = require("./utils");
 const app = express();
 
 const isDev = process.env.NODE_ENV !== "production";
@@ -80,9 +71,9 @@ app.get("/kpm/logout", (req, res) => {
 
 app.use("/kpm/panels", panelsRouter);
 app.get("/kpm", async (req, res) => {
-  const footer = await fetchBlock("footer");
-  const megaMenu = await fetchBlock("megaMenu");
-  const search = await fetchBlock("search");
+  const footer = await fetchCortinaBlock("footer");
+  const megaMenu = await fetchCortinaBlock("megaMenu");
+  const search = await fetchCortinaBlock("search");
 
   res.send(
     infoPageTemplate({

--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,4 @@
 const session = require("express-session");
-const got = require("got");
 const loginRouter = require("./login-router");
 const panelsRouter = require("./panels/router");
 const log = require("skog");
@@ -12,31 +11,9 @@ if (isDev) {
   log.info("App is in development mode");
 }
 
-const blocks = {
-  title: "1.260060",
-  megaMenu: "1.855134",
-  secondaryMenu: "1.865038",
-  image: "1.77257",
-  footer: "1.202278",
-  search: "1.77262",
-  language: {
-    en: "1.77273",
-    sv: "1.272446",
-  },
-  analytics: "1.464751",
-  gtmAnalytics: "1.714097",
-  gtmNoscript: "1.714099",
-};
-
 const infoPageTemplate = compileTemplate(__dirname, "info-page.handlebars");
 
-async function fetchBlock(str) {
-  const res = await got.get(`https://www.kth.se/cm/${blocks[str]}`);
-  return res.body;
-}
-
 app.set("trust proxy", 1);
-
 app.use(
   session({
     name: "kpm",

--- a/server/utils.js
+++ b/server/utils.js
@@ -1,6 +1,8 @@
 const handlebars = require("handlebars");
 const path = require("path");
 const fs = require("fs");
+const log = require("skog");
+const got = require("got");
 
 function compileTemplate(resolvePath, name) {
   return handlebars.compile(
@@ -10,4 +12,53 @@ function compileTemplate(resolvePath, name) {
   );
 }
 
-module.exports = { compileTemplate };
+// In-memory cached Cortina blocks. It stores Promises of blocks, not the
+// actual content
+const cachedBlocks = {};
+const blockIds = {
+  title: "1.260060",
+  megaMenu: "1.855134",
+  secondaryMenu: "1.865038",
+  image: "1.77257",
+  footer: "1.202278",
+  search: "1.77262",
+  language: {
+    en: "1.77273",
+    sv: "1.272446",
+  },
+  analytics: "1.464751",
+  gtmAnalytics: "1.714097",
+  gtmNoscript: "1.714099",
+};
+
+/** Renew a cached-block */
+async function renewCortinaBlock(str) {
+  log.info(`Renewing Cortina block ${str}`);
+
+  const body = got
+    .get(`https://www.kth.se/cm/${blocks[str]}`)
+    .then((res) => res.body);
+
+  await body;
+
+  // We store the Promise after getting the value, not the value
+  cachedBlocks[str] = body;
+}
+
+/** Returns the cached-version of the block or fetches it */
+async function fetchCortinaBlock(str) {
+  if (cachedBlocks[str]) {
+    log.debug(`Cache hit for Cortina block ${str}`);
+    return cachedBlocks[str];
+  }
+
+  // We don't await here. Instead we return the promise
+  const body = got
+    .get(`https://www.kth.se/cm/${blockIds[str]}`)
+    .then((res) => res.body);
+
+  cachedBlocks[str] = body;
+  return body;
+}
+
+module.exports = { compileTemplate, fetchCortinaBlock, renewCortinaBlock };

--- a/server/utils.js
+++ b/server/utils.js
@@ -36,29 +36,16 @@ async function renewCortinaBlock(str) {
   log.info(`Renewing Cortina block ${str}`);
 
   const body = got
-    .get(`https://www.kth.se/cm/${blocks[str]}`)
-    .then((res) => res.body);
-
-  await body;
-
-  // We store the Promise after getting the value, not the value
-  cachedBlocks[str] = body;
-}
-
-/** Returns the cached-version of the block or fetches it */
-async function fetchCortinaBlock(str) {
-  if (cachedBlocks[str]) {
-    log.debug(`Cache hit for Cortina block ${str}`);
-    return cachedBlocks[str];
-  }
-
-  // We don't await here. Instead we return the promise
-  const body = got
     .get(`https://www.kth.se/cm/${blockIds[str]}`)
     .then((res) => res.body);
 
-  cachedBlocks[str] = body;
-  return body;
+  // We store the Promise after getting the value, not the value
+  cachedBlocks[str] = await body;
+}
+
+/** Returns the cached-version of the block or fetches it */
+function fetchCortinaBlock(str) {
+  return cachedBlocks[str] || `<!-- Missing Cortina block ${str} -->`;
 }
 
 module.exports = { compileTemplate, fetchCortinaBlock, renewCortinaBlock };


### PR DESCRIPTION
<details>
<summary>Benchmarks</summary>

Test: 1000 connections (100 concurrent) towards KPM deployed locally

## Without cache:

```
$ ab -n 1000 -c 100 http://localdev.kth.se:3000/kpm
  50%   4753
  66%   6217
  75%  21815
  80%  23063
  90%  24254
  95%  30507
  98%  84960
  99%  87397
 100%  100676 (longest request)
```

## With cache

```
$ ab -n 1000 -c 100 http://localdev.kth.se:3000/kpm
  50%    119
  66%    130
  75%    134
  80%    138
  90%    150
  95%    156
  98%    173
  99%    174
 100%    174 (longest request)
```
</details>