### PR TITLE
Load course names

### DIFF
--- a/.env.in
+++ b/.env.in
@@ -5,3 +5,7 @@ SESSION_SECRET=example
 OPENID_URL=https://login.ref.ug.kth.se/adfs
 OPENID_CLIENT_ID=
 OPENID_CLIENT_SECRET=
+
+# Connection string (with password) for redis.
+# If undefined, redis will default to localhost.
+# REDIS_URL=

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "js-cookie": "^2.2.1",
         "kth-style": "^6.0.1",
         "openid-client": "^4.5.0",
+        "redis": "^3.0.2",
         "skog": "^1.0.1-alpha.0"
       },
       "devDependencies": {
@@ -3699,6 +3700,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -8345,6 +8354,48 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
+      "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
+      "dependencies": {
+        "denque": "^1.4.1",
+        "redis-commands": "^1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-redis"
+      }
+    },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/regenerate": {
@@ -13785,6 +13836,11 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -17604,6 +17660,35 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "redis": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
+      "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
+      "requires": {
+        "denque": "^1.4.1",
+        "redis-commands": "^1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
       }
     },
     "regenerate": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "js-cookie": "^2.2.1",
     "kth-style": "^6.0.1",
     "openid-client": "^4.5.0",
+    "redis": "^3.0.2",
     "skog": "^1.0.1-alpha.0"
   },
   "devDependencies": {

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -38,6 +38,8 @@ async function lookupCourseData(courseCode) {
     return data;
   } catch (error) {
     log.error({ courseCode, err: error }, "Failed to get kopps info.");
+    // Mock some empty data, so the panel doesn't 500 and the course code
+    // and other names are still visible.
     return { courseCode, name: { en: "-", sv: "-" } };
   }
 }

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -6,11 +6,11 @@ const redis = require("redis").createClient({
 // Note about the kopps timeout: For most courses we get our reply in
 // less than 200 ms but some (e.g. SF1624) gives a timeout even at 500
 // ms.  But since that is the rare case and we cache the results in
-// redis, just increase the timeout to a whole second.
+// redis, just increase the timeout to 2 whole seconds.
 const kopps = require("got").extend({
   prefixUrl: "https://api.kth.se/api/kopps/v2",
   responseType: "json",
-  timeout: 1000, // milliseconds
+  timeout: 2000, // milliseconds
 });
 
 const { promisify } = require("util");

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -3,10 +3,14 @@ const redis = require("redis").createClient({
   url: process.env.REDIS_URL,
 });
 
+// Note about the kopps timeout: For most courses we get our reply in
+// less than 200 ms but some (e.g. SF1624) gives a timeout even at 500
+// ms.  But since that is the rare case and we cache the results in
+// redis, just increase the timeout to a whole second.
 const kopps = require("got").extend({
   prefixUrl: "https://api.kth.se/api/kopps/v2",
   responseType: "json",
-  timeout: 500, // milliseconds
+  timeout: 1000, // milliseconds
 });
 
 const { promisify } = require("util");

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -1,6 +1,6 @@
 const log = require("skog");
 const redis = require("redis").createClient({
-  'url': process.env.REDIS_URL,
+  url: process.env.REDIS_URL,
 });
 
 const kopps = require("got").extend({

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -1,5 +1,7 @@
 const log = require("skog");
-const redis = require("redis").createClient();
+const redis = require("redis").createClient({
+  'url': process.env.REDIS_URL,
+});
 
 const kopps = require("got").extend({
   prefixUrl: "https://api.kth.se/api/kopps/v2",

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -10,6 +10,7 @@ const { promisify } = require("util");
 const cache = {
   get: promisify(redis.get).bind(redis),
   set: promisify(redis.set).bind(redis),
+  expire: 61 * 60 * 24, // slightly more than 24 hours.
 };
 
 async function lookupCourseData(courseCode) {
@@ -26,7 +27,7 @@ async function lookupCourseData(courseCode) {
       courseCode,
       name: body.title,
     };
-    await cache.set(key, JSON.stringify(data));
+    await cache.set(key, JSON.stringify(data), "EX", cache.expire);
     return data;
   } catch (error) {
     log.error({ courseCode, err: error }, "Failed to get kopps info.");

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -6,6 +6,7 @@ const redis = require("redis").createClient({
 const kopps = require("got").extend({
   prefixUrl: "https://api.kth.se/api/kopps/v2",
   responseType: "json",
+  timeout: 200, // milliseconds
 });
 
 const { promisify } = require("util");

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -6,7 +6,7 @@ const redis = require("redis").createClient({
 const kopps = require("got").extend({
   prefixUrl: "https://api.kth.se/api/kopps/v2",
   responseType: "json",
-  timeout: 200, // milliseconds
+  timeout: 500, // milliseconds
 });
 
 const { promisify } = require("util");

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -36,7 +36,8 @@ async function lookupCourseData(courseCode) {
 }
 
 module.exports = async function extractInfoFromToken(token) {
-  const completedCourses = [];
+  const completedStudentCourses = [];
+  const activeStudentCourses = []; // TODO
   const COMPLETED_COURSE_REGEX = /^ladok2\.kurser\.(\w+)\.(\w+)\.godkand$/;
 
   for (const group of token.memberOf) {
@@ -45,12 +46,13 @@ module.exports = async function extractInfoFromToken(token) {
     if (match) {
       const courseCode = `${match[1]}${match[2]}`;
       const courseData = await lookupCourseData(courseCode);
-      completedCourses.push(courseData);
+      completedStudentCourses.push(courseData);
     }
   }
 
   return {
     fullName: token.unique_name[0],
-    completedCourses,
+    completedStudentCourses,
+    activeStudentCourses,
   };
 };

--- a/server/openid/extract-info.js
+++ b/server/openid/extract-info.js
@@ -1,6 +1,21 @@
+const log = require("skog");
+
+const kopps = require("got").extend({
+  prefixUrl: "https://api.kth.se/api/kopps/v2",
+  responseType: "json",
+});
+
 async function lookupCourseData(courseCode) {
-  // TODO
-  return { courseCode, name: { en: "TODO", sv: "ATTGÖRA" } };
+  try {
+    const { body } = await kopps(`course/${courseCode}`);
+    return {
+      courseCode,
+      name: body.title,
+    };
+  } catch (error) {
+    log.error({ courseCode, error }, "Failed to get kopps info.");
+    return { courseCode, name: { en: "-", sv: "-" } };
+  }
 }
 
 module.exports = async function extractInfoFromToken(token) {

--- a/server/panels/router.js
+++ b/server/panels/router.js
@@ -1,7 +1,6 @@
 const log = require("skog");
 const { Router } = require("express");
 const { compileTemplate } = require("../utils");
-const mock = require("../../db-stub");
 
 const panelsRouter = Router();
 

--- a/server/panels/router.js
+++ b/server/panels/router.js
@@ -57,7 +57,7 @@ panelsRouter.get("/hello", (req, res) => {
 panelsRouter.get("/studies", (req, res) => {
   log.info("Requesting panel '/studies'");
   if (req.session.userId) {
-    const data = mock.u1znmoik;
+    const data = req.session.userData;
     for (const course of data.activeStudentCourses) {
       const canvasLinks = [];
       for (const round of course.courseRounds) {

--- a/server/panels/router.js
+++ b/server/panels/router.js
@@ -41,7 +41,6 @@ panelsRouter.get("/", (req, res) => {
 panelsRouter.get("/hello", (req, res) => {
   log.info("Requesting panel '/hello'");
   if (req.session.userId) {
-    log.info(req.session.userData);
     res.send(
       helloPanel({
         userName: req.session.userId,


### PR DESCRIPTION
Load course name (in swedish and english) from kopps, with redis caching.

To do before merging:
- [x] Configure REDIS_URL though env (was: This just creates the redis client with default parameters.  Will that be correct in azure, or do we need to handle environment variables and pass them as parameters to redis `createClient()`?)
- [ ] This puts all of the kopps and redis code directly in `server/openid/extract-info.js`.  It's not too long (yet), but maybe it should be some other structure anyway?
- [x] Redis is a cache, so how do we specify how long time to cache things?