### PR TITLE
Canvas auth in kpm.

### DIFF
--- a/kpm/kpm-backend/.env.in
+++ b/kpm/kpm-backend/.env.in
@@ -9,5 +9,8 @@ OIDC_URL=https://login.ref.ug.kth.se/adfs
 OIDC_CLIENT_ID=
 OIDC_CLIENT_SECRET=
 
+# Credentials for canvas api (should include the "Bearer" prefix).
+CANVAS_TOKEN=
+
 # String used to encode/decode session cookies
 SESSION_SECRET=

--- a/kpm/kpm-backend/src/api.ts
+++ b/kpm/kpm-backend/src/api.ts
@@ -9,6 +9,7 @@ const MY_TEACHING_API_URI =
   process.env.MY_TEACHING_API_URI || "http://localhost:3002/kpm/teaching";
 const MY_STUDIES_API_URI =
   process.env.MY_STUDIES_API_URI || "http://localhost:3003/kpm/studies";
+const CANVAS_TOKEN = process.env.CANVAS_TOKEN;
 
 export const api = express.Router();
 
@@ -25,6 +26,9 @@ api.get("/canvas-rooms", async (req, res, next) => {
     const { rooms } = await got
       .get<any>(`${MY_CANVAS_ROOMS_API_URI}/user/u1famwov`, {
         responseType: "json",
+        headers: {
+          authorization: CANVAS_TOKEN,
+        },
       })
       .then((r) => r.body);
 


### PR DESCRIPTION
KPM backend should have and use a canvas authentication token for calling my-canvas-rooms-api.