### PR TITLE
Make kpm-backend teaching response more complete.

### DIFF
--- a/kpm/kpm-backend-interface/src/index.ts
+++ b/kpm/kpm-backend-interface/src/index.ts
@@ -3,7 +3,7 @@ export type APICanvasRooms = {
 };
 
 export type APITeaching = {
-  courses: { [index: string]: TTeachingCourse[] };
+  courses: Record<string, TTeachingCourse>;
 };
 
 export type APIStudies = {
@@ -25,6 +25,14 @@ export type TCanvasRoom = {
 };
 
 export type TTeachingCourse = {
+  title: { sv: string; en: string };
+  credits: number;
+  creditUnitAbbr: string; // usually "hp", check other values!
+  roles: TTeachingRole[];
+  rooms: TCanvasRoom[];
+};
+
+export type TTeachingRole = {
   role: "courseresponsible" | "teachers" | "assistants" | "examiner";
   round_id: string;
   term: "1" | "2";

--- a/kpm/kpm-backend-interface/src/index.ts
+++ b/kpm/kpm-backend-interface/src/index.ts
@@ -11,7 +11,6 @@ export type APIStudies = {
   programmes: TStudiesProgramme[];
 };
 
-
 export type TCourseCode = string;
 
 // QUESTION: Should we import types from the API-packages? Should these types be moved to separate packages?

--- a/kpm/kpm-backend-interface/src/index.ts
+++ b/kpm/kpm-backend-interface/src/index.ts
@@ -25,6 +25,7 @@ export type TCanvasRoom = {
 };
 
 export type TTeachingCourse = {
+  course_code: string;
   title: { sv: string; en: string };
   credits: number;
   creditUnitAbbr: string; // usually "hp", check other values!

--- a/kpm/kpm-backend-interface/src/index.ts
+++ b/kpm/kpm-backend-interface/src/index.ts
@@ -1,15 +1,18 @@
 export type APICanvasRooms = {
-  rooms: { [index: string]: TCanvasRoom };
+  rooms: { [index: TCourseCode]: TCanvasRoom };
 };
 
 export type APITeaching = {
-  courses: Record<string, TTeachingCourse>;
+  courses: Record<TCourseCode, TTeachingCourse>;
 };
 
 export type APIStudies = {
   courses: TStudiesCourse[];
   programmes: TStudiesProgramme[];
 };
+
+
+export type TCourseCode = string;
 
 // QUESTION: Should we import types from the API-packages? Should these types be moved to separate packages?
 // Same as type Link in my-canvas-rooms-api/src/api.ts
@@ -25,7 +28,7 @@ export type TCanvasRoom = {
 };
 
 export type TTeachingCourse = {
-  course_code: string;
+  course_code: TCourseCode;
   title: { sv: string; en: string };
   credits: number;
   creditUnitAbbr: string; // usually "hp", check other values!

--- a/kpm/kpm-backend/.env.in
+++ b/kpm/kpm-backend/.env.in
@@ -9,8 +9,8 @@ OIDC_URL=https://login.ref.ug.kth.se/adfs
 OIDC_CLIENT_ID=
 OIDC_CLIENT_SECRET=
 
-# Credentials for canvas api (should include the "Bearer" prefix).
-CANVAS_TOKEN=
+# Credentials for canvas api
+CANVAS_API_TOKEN=
 
 # String used to encode/decode session cookies
 SESSION_SECRET=

--- a/kpm/kpm-backend/package-lock.json
+++ b/kpm/kpm-backend/package-lock.json
@@ -21,6 +21,7 @@
         "got": "^11.8.5",
         "kpm-api-common": "^0.1.0",
         "kpm-backend-interface": "^0.1.0",
+        "node-cache": "^5.1.2",
         "openid-client": "^5.2.1",
         "skog": "^3.0.2",
         "ts-node": "^10.9.1"
@@ -1986,6 +1987,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/clone-response": {
@@ -4127,6 +4136,17 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -7184,6 +7204,11 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+    },
     "clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -8822,6 +8847,14 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      }
     },
     "node-int64": {
       "version": "0.4.0",

--- a/kpm/kpm-backend/package.json
+++ b/kpm/kpm-backend/package.json
@@ -28,6 +28,7 @@
     "got": "^11.8.5",
     "kpm-api-common": "^0.1.0",
     "kpm-backend-interface": "^0.1.0",
+    "node-cache": "^5.1.2",
     "openid-client": "^5.2.1",
     "skog": "^3.0.2",
     "ts-node": "^10.9.1"

--- a/kpm/kpm-backend/src/api.ts
+++ b/kpm/kpm-backend/src/api.ts
@@ -5,6 +5,7 @@ import {
   APITeaching,
   APICanvasRooms,
   TTeachingCourse,
+  TTeachingRole,
 } from "kpm-backend-interface";
 
 const MY_CANVAS_ROOMS_API_URI =
@@ -50,9 +51,12 @@ api.get("/teaching", async (req, res, next) => {
   const user = "u1i6bme8"; // FIXME: Get kthid of logged in user!
   try {
     const teaching = await got
-      .get<any>(`${MY_TEACHING_API_URI}/user/${user}`, {
-        responseType: "json",
-      })
+      .get<Record<string, TTeachingRole[]>>(
+        `${MY_TEACHING_API_URI}/user/${user}`,
+        {
+          responseType: "json",
+        }
+      )
       .then((r) => r.body);
 
     const { rooms } = await got
@@ -65,17 +69,16 @@ api.get("/teaching", async (req, res, next) => {
       .then((r) => r.body);
 
     let courses: Record<string, TTeachingCourse> = {};
-    for (let course_code in teaching) {
-      if (course_code != "-") {
-        const kopps = await getCourseInfo(course_code);
-        courses[course_code] = {
-          title: kopps.title,
-          credits: kopps.credits,
-          creditUnitAbbr: kopps.creditUnitAbbr,
-          roles: teaching[course_code],
-          rooms: rooms[course_code],
-        };
-      }
+    for (let [course_code, roles] of Object.entries(teaching)) {
+      const kopps = await getCourseInfo(course_code);
+      courses[course_code] = {
+        course_code: course_code,
+        title: kopps.title,
+        credits: kopps.credits,
+        creditUnitAbbr: kopps.creditUnitAbbr,
+        roles: roles,
+        rooms: rooms[course_code],
+      };
     }
 
     res.send({ courses });

--- a/kpm/kpm-backend/src/api.ts
+++ b/kpm/kpm-backend/src/api.ts
@@ -6,6 +6,7 @@ import {
   APICanvasRooms,
   TTeachingCourse,
   TTeachingRole,
+  TCourseCode,
 } from "kpm-backend-interface";
 
 const MY_CANVAS_ROOMS_API_URI =
@@ -51,7 +52,7 @@ api.get("/teaching", async (req, res, next) => {
   const user = "u1i6bme8"; // FIXME: Get kthid of logged in user!
   try {
     const teaching_fut = got
-      .get<Record<string, TTeachingRole[]>>(
+      .get<Record<TCourseCode, TTeachingRole[]>>(
         `${MY_TEACHING_API_URI}/user/${user}`,
         {
           responseType: "json",
@@ -78,7 +79,7 @@ api.get("/teaching", async (req, res, next) => {
     );
     const { rooms } = await rooms_fut;
 
-    let courses: Record<string, TTeachingCourse> = {};
+    let courses: Record<TCourseCode, TTeachingCourse> = {};
     for (let [course_code, roles] of Object.entries(teaching)) {
       const kopps = await kopps_futs[course_code];
       courses[course_code] = {
@@ -114,7 +115,7 @@ api.get("/studies", async (req, res, next) => {
   }
 });
 
-async function getCourseInfo(course_code: string) {
+async function getCourseInfo(course_code: TCourseCode) {
   const { title, credits, creditUnitAbbr } = await got
     .get<{
       title: { sv: string; en: string };

--- a/kpm/kpm-backend/src/api.ts
+++ b/kpm/kpm-backend/src/api.ts
@@ -18,7 +18,7 @@ const MY_TEACHING_API_URI =
   process.env.MY_TEACHING_API_URI || "http://localhost:3002/kpm/teaching";
 const MY_STUDIES_API_URI =
   process.env.MY_STUDIES_API_URI || "http://localhost:3003/kpm/studies";
-const CANVAS_TOKEN = process.env.CANVAS_TOKEN;
+const CANVAS_API_TOKEN = process.env.CANVAS_API_TOKEN;
 const KOPPS_API = "https://api.kth.se/api/kopps/v2";
 
 export const api = express.Router();
@@ -37,7 +37,7 @@ api.get("/canvas-rooms", async (req, res, next) => {
       .get<any>(`${MY_CANVAS_ROOMS_API_URI}/user/u1famwov`, {
         responseType: "json",
         headers: {
-          authorization: CANVAS_TOKEN,
+          authorization: CANVAS_API_TOKEN,
         },
       })
       .then((r) => r.body);
@@ -66,7 +66,7 @@ api.get("/teaching", async (req, res, next) => {
       .get<any>(`${MY_CANVAS_ROOMS_API_URI}/user/${user}`, {
         responseType: "json",
         headers: {
-          authorization: CANVAS_TOKEN,
+          authorization: `Bearer ${CANVAS_API_TOKEN}`,
         },
       })
       .then((r) => r.body);
@@ -144,7 +144,7 @@ async function getCourseInfo(course_code: TCourseCode) {
     const info = { title, credits, creditUnitAbbr };
     kopps_cache.set(course_code, info);
     return info;
-  } catch (err) {
+  } catch (err: any) {
     log.error(err, `Failed to get kopps data for ${course_code}`);
     // Ugly but type-correct fallback, so things don't crash.
     // This is not cached!  Or should we cache it for a few minutes to

--- a/kpm/kpm-backend/src/api.ts
+++ b/kpm/kpm-backend/src/api.ts
@@ -50,7 +50,7 @@ api.get("/canvas-rooms", async (req, res, next) => {
 api.get("/teaching", async (req, res, next) => {
   const user = "u1i6bme8"; // FIXME: Get kthid of logged in user!
   try {
-    const teaching = await got
+    const teaching_fut = got
       .get<Record<string, TTeachingRole[]>>(
         `${MY_TEACHING_API_URI}/user/${user}`,
         {
@@ -59,7 +59,7 @@ api.get("/teaching", async (req, res, next) => {
       )
       .then((r) => r.body);
 
-    const { rooms } = await got
+    const rooms_fut = got
       .get<any>(`${MY_CANVAS_ROOMS_API_URI}/user/${user}`, {
         responseType: "json",
         headers: {
@@ -67,6 +67,9 @@ api.get("/teaching", async (req, res, next) => {
         },
       })
       .then((r) => r.body);
+
+    const teaching = await teaching_fut;
+    const { rooms } = await rooms_fut;
 
     let courses: Record<string, TTeachingCourse> = {};
     for (let [course_code, roles] of Object.entries(teaching)) {

--- a/kpm/kpm-backend/src/api.ts
+++ b/kpm/kpm-backend/src/api.ts
@@ -69,11 +69,18 @@ api.get("/teaching", async (req, res, next) => {
       .then((r) => r.body);
 
     const teaching = await teaching_fut;
+
+    const kopps_futs = Object.assign(
+      {},
+      ...Object.keys(teaching).map((course_code) => ({
+        [course_code]: getCourseInfo(course_code),
+      }))
+    );
     const { rooms } = await rooms_fut;
 
     let courses: Record<string, TTeachingCourse> = {};
     for (let [course_code, roles] of Object.entries(teaching)) {
-      const kopps = await getCourseInfo(course_code);
+      const kopps = await kopps_futs[course_code];
       courses[course_code] = {
         course_code: course_code,
         title: kopps.title,

--- a/kpm/kpm-frontend/src/panes/i18n.ts
+++ b/kpm/kpm-frontend/src/panes/i18n.ts
@@ -1,0 +1,10 @@
+export type TLang = "sv" | "en";
+
+export function i18n(strObj: Record<TLang, string> | string, lang: TLang = "sv") {
+  if (typeof strObj === "object") {
+    return strObj[lang];
+  }
+  
+  // TODO: Create language dict for static string lookup
+  return strObj;
+}

--- a/kpm/kpm-frontend/src/panes/i18n.ts
+++ b/kpm/kpm-frontend/src/panes/i18n.ts
@@ -1,10 +1,13 @@
 export type TLang = "sv" | "en";
 
-export function i18n(strObj: Record<TLang, string> | string, lang: TLang = "sv") {
+export function i18n(
+  strObj: Record<TLang, string> | string,
+  lang: TLang = "sv"
+) {
   if (typeof strObj === "object") {
     return strObj[lang];
   }
-  
+
   // TODO: Create language dict for static string lookup
   return strObj;
 }

--- a/kpm/kpm-frontend/src/panes/teaching.scss
+++ b/kpm/kpm-frontend/src/panes/teaching.scss
@@ -1,14 +1,14 @@
 #kpm-6cf53 .kpm-teaching {
   display: flex;
   flex-flow: row wrap;
-  gap: var(--kpmMargin);
+  gap: calc(3 * var(--kpmGap));
 
   .kpm-teaching-course {
-    width: calc(50% - var(--kpmMargin) / 2);
+    width: calc(100% / 3);
     display: flex;
     flex-direction: column;
-    gap: 0.5em;
-    padding: var(--kpmPad);
+    gap: var(--kpmGap);
+    padding: calc(2 * var(--kpmPad));
     background-color: var(--kpmGroupBg);
 
     h2 {
@@ -17,11 +17,16 @@
       padding: 0;
     }
 
+    li {
+      margin: calc(1.5 * var(--kpmMargin)) 0;
+    }
+
     hr {
       height: 1px;
       background: var(--kpmGroupFg);
       width: 100%;
       border: 0;
+      margin: 0;
     }
   }
 }

--- a/kpm/kpm-frontend/src/panes/teaching.tsx
+++ b/kpm/kpm-frontend/src/panes/teaching.tsx
@@ -1,6 +1,10 @@
 import * as React from "react";
 import { useLoaderData } from "react-router-dom";
-import { APITeaching, TCanvasRoom, TTeachingCourse } from "kpm-backend-interface";
+import {
+  APITeaching,
+  TCanvasRoom,
+  TTeachingCourse,
+} from "kpm-backend-interface";
 import { MenuPane } from "../components/menu";
 import { CollapsableGroup, GroupItem } from "../components/groups";
 import { i18n } from "./i18n";
@@ -22,13 +26,7 @@ export function Teaching() {
     <MenuPane>
       <div className="kpm-teaching">
         {Object.entries(courses).map(([code, course]) => {
-          return (
-            <Course
-              key={[code]}
-              courseCode={code}
-              course={course}
-            />
-          );
+          return <Course key={[code]} courseCode={code} course={course} />;
         })}
       </div>
     </MenuPane>
@@ -166,12 +164,11 @@ function CanvasRoomExpandedList({ rooms }: any) {
   );
 }
 
-
 type TCanvasRoomItemProps = {
-  url: string,
-  code?: string,
-  startTerm: string,
-}
+  url: string;
+  code?: string;
+  startTerm: string;
+};
 
 function CanvasRoomItem({ url, code, startTerm }: TCanvasRoomItemProps) {
   // This is a Component to force consistency
@@ -219,6 +216,6 @@ function filterCanvasRooms(rooms: TCanvasRoom[]): {
 function formatTerm(startTerm: string) {
   const shortYear = startTerm.slice(2, 4);
   const termNr = startTerm.slice(4, 5);
-  const termStr = { 1: "VT", 2: "HT"}[termNr];
+  const termStr = { 1: "VT", 2: "HT" }[termNr];
   return `${termStr}${shortYear}`;
 }

--- a/kpm/kpm-frontend/src/panes/teaching.tsx
+++ b/kpm/kpm-frontend/src/panes/teaching.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
 import { useLoaderData } from "react-router-dom";
-import { APITeaching, TTeachingCourse } from "kpm-backend-interface";
+import { APITeaching, TCanvasRoom, TTeachingCourse } from "kpm-backend-interface";
 import { MenuPane } from "../components/menu";
 import { CollapsableGroup, GroupItem } from "../components/groups";
+import { i18n } from "./i18n";
 
 import "./teaching.scss";
 
@@ -20,12 +21,12 @@ export function Teaching() {
   return (
     <MenuPane>
       <div className="kpm-teaching">
-        {Object.keys(courses).map((course_code: string) => {
+        {Object.entries(courses).map(([code, course]) => {
           return (
             <Course
-              key={course_code}
-              courseCode={course_code}
-              courseRounds={courses[course_code]}
+              key={[code]}
+              courseCode={code}
+              course={course}
             />
           );
         })}
@@ -34,11 +35,11 @@ export function Teaching() {
   );
 }
 
-function Course({ courseCode, courseRounds }: any) {
-  const courseName = "[course name missing]";
-  const aboutCourseUrl = "[aboutCourseUrl missing]";
+function Course({ courseCode, course }: any) {
+  const courseName = i18n(course.title); // TODO: perhaps convert i18n to i18nHook that fetches language and returns i18n function
+  const aboutCourseUrl = `https://www.kth.se/kurs-pm/${courseCode}/om-kurs-pm`;
   // TODO: These should be changed to course rooms, check backend
-  const { current, other } = filterCanvasRooms(courseRounds);
+  const { current, other } = filterCanvasRooms(course.rooms);
   const currentTerm = "HT2022";
 
   return (
@@ -129,16 +130,13 @@ function Course({ courseCode, courseRounds }: any) {
 function CanvasRoomShortList({ rooms }: any) {
   return (
     <ul>
-      {rooms.map(({ year, role, term, round_id }: any) => {
-        const key = `${year}-${term}-${round_id}-${role}`;
+      {rooms.map((room: TCanvasRoom) => {
         return (
-          <li>
+          <li key={room.startTerm}>
             <CanvasRoomItem
-              key={key}
-              url={"#TODO"}
-              term={term}
-              year={year}
-              roundId={round_id}
+              url={room.url.toString()}
+              code={room.text}
+              startTerm={room.startTerm!}
             />
           </li>
         );
@@ -153,16 +151,13 @@ function CanvasRoomExpandedList({ rooms }: any) {
 
   return (
     <CollapsableGroup title="Äldre kursrum">
-      {rooms.map(({ year, role, term, round_id }: any) => {
-        const key = `${year}-${term}-${round_id}-${role}`;
+      {rooms.map((room: TCanvasRoom) => {
         return (
-          <GroupItem>
+          <GroupItem key={room.startTerm}>
             <CanvasRoomItem
-              key={key}
-              url={"#TODO"}
-              term={term}
-              year={year}
-              roundId={round_id}
+              url={room.url.toString()}
+              code={room.text}
+              startTerm={room.startTerm!}
             />
           </GroupItem>
         );
@@ -171,29 +166,34 @@ function CanvasRoomExpandedList({ rooms }: any) {
   );
 }
 
-function CanvasRoomItem({ url, term, year, roundId }: any) {
+
+type TCanvasRoomItemProps = {
+  url: string,
+  code?: string,
+  startTerm: string,
+}
+
+function CanvasRoomItem({ url, code, startTerm }: TCanvasRoomItemProps) {
   // This is a Component to force consistency
   return (
     <a href={url}>
-      {formatTerm(term)}
-      {year} ({roundId})
+      Kursrum {startTerm && formatTerm(startTerm)} {`(${code || "-- ? --"})`}
     </a>
   );
 }
 
-function filterCanvasRooms(rooms: TTeachingCourse[]): {
-  current: TTeachingCourse[];
-  other: TTeachingCourse[];
+function filterCanvasRooms(rooms: TCanvasRoom[]): {
+  current: TCanvasRoom[];
+  other: TCanvasRoom[];
 } {
-  const now = new Date();
   const outp = [...rooms];
 
-  outp.sort((a: TTeachingCourse, b: TTeachingCourse) => {
-    try {
-      return (parseInt(a.year) - parseInt(b.year)) % 1;
-    } catch (e) {
-      return 0;
-    }
+  outp.sort((a: TCanvasRoom, b: TCanvasRoom) => {
+    const aVal = parseInt(a.startTerm || "0");
+    const bVal = parseInt(b.startTerm || "0");
+    if (aVal === bVal) return 0;
+    if (aVal > bVal) return -1;
+    return 1;
   });
 
   if (outp.length <= 4) {
@@ -216,13 +216,9 @@ function filterCanvasRooms(rooms: TTeachingCourse[]): {
   };
 }
 
-function formatTerm(term: string) {
-  switch (term) {
-    case "1":
-      return "VT";
-    case "2":
-      return "HT";
-    default:
-      return "??";
-  }
+function formatTerm(startTerm: string) {
+  const shortYear = startTerm.slice(2, 4);
+  const termNr = startTerm.slice(4, 5);
+  const termStr = { 1: "VT", 2: "HT"}[termNr];
+  return `${termStr}${shortYear}`;
 }

--- a/kpm/kpm-frontend/src/stylesVars.scss
+++ b/kpm/kpm-frontend/src/stylesVars.scss
@@ -14,4 +14,5 @@ html {
 
   --kpmPad: 0.5rem;
   --kpmMargin: 0.75rem;
+  --kpmGap: 0.35em;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
         "got": "^11.8.5",
         "kpm-api-common": "^0.1.0",
         "kpm-backend-interface": "^0.1.0",
+        "node-cache": "^5.1.2",
         "openid-client": "^5.2.1",
         "skog": "^3.0.2",
         "ts-node": "^10.9.1"
@@ -3322,7 +3323,6 @@
     },
     "node_modules/clone": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -6381,6 +6381,17 @@
       "version": "3.2.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -11050,8 +11061,7 @@
       }
     },
     "clone": {
-      "version": "2.1.2",
-      "dev": true
+      "version": "2.1.2"
     },
     "clone-response": {
       "version": "1.0.3",
@@ -12796,6 +12806,7 @@
         "got": "^11.8.5",
         "kpm-api-common": "^0.1.0",
         "kpm-backend-interface": "^0.1.0",
+        "node-cache": "*",
         "openid-client": "^5.2.1",
         "pino-pretty": "^9.1.1",
         "prettier": "^2.7.1",
@@ -13140,6 +13151,14 @@
     "node-addon-api": {
       "version": "3.2.1",
       "dev": true
+    },
+    "node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "requires": {
+        "clone": "2.x"
+      }
     },
     "node-domexception": {
       "version": "1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "kpm/*"
       ],
       "dependencies": {
-        "evolene-local-packages": "^0.1.0"
+        "evolene-local-packages": "^0.1.0",
+        "lightningcss": "^1.16.0"
       },
       "devDependencies": {
         "npm-run-all": "^4.1.5"
@@ -3681,7 +3682,6 @@
     },
     "node_modules/detect-libc": {
       "version": "1.0.3",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "detect-libc": "bin/detect-libc.js"
@@ -6007,8 +6007,8 @@
     },
     "node_modules/lightningcss": {
       "version": "1.16.0",
-      "dev": true,
-      "license": "MPL-2.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.16.0.tgz",
+      "integrity": "sha512-5+ZS9h+xeADcJTF2oRCT3yNZBlDYyOgQSdrWNBCqsIwm8ucKbF061OBVv/WHP4Zk8FToNhwFklk/hMuOngqsIg==",
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -6030,16 +6030,148 @@
         "lightningcss-win32-x64-msvc": "1.16.0"
       }
     },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.0.tgz",
+      "integrity": "sha512-gIhz6eZFwsC4oVMjBGQ3QWDdLQY7vcXFyM/x91PilgHqu63B9uBa10EZA75YoTEkbKhoz0uDCqyHh/EoF1GrkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lightningcss-darwin-x64": {
       "version": "1.16.0",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.0.tgz",
+      "integrity": "sha512-oSwEbvXUPr//H/ainBRJXTxHerlheee/KgkTTmAQWiVnt8HV+bRohTBWWPBy5ZArgiGLwj7ogv45istgljPN2Q==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.0.tgz",
+      "integrity": "sha512-Drq9BSVIvmV9zsDJbCZWCulMvKMQWFIlYXPCKV/iwRj+ZAJ1BRngma0cNHB6uW7Wac8Jg04CJN5IA4ELE3J+cQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.0.tgz",
+      "integrity": "sha512-1QXWStnTEo4RFQf0mfGhRyNUeEHilCZ0NA97XgwKwrYr/M7sYKU/1HWY00dPxFJ6GITR2pfJGo9xi3ScSSBxbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.0.tgz",
+      "integrity": "sha512-gD2eQYD5OFs1p83R0TcMCEc5HRyJES4lR4THmclv7khm3dc9vc+2VT0kFBPxO1L2AwlZuvXaaMan7X1Ul7uSfA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.0.tgz",
+      "integrity": "sha512-HJsKeYxloEvg2WCQhtYPqzZUliLu9JBJNeI5y9cPQeDR/7ayGGLbVhJaotPtzJkElOFL/SaXsS+FRuH4w+yafg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.0.tgz",
+      "integrity": "sha512-h4ayyAlOMLUHV9NdofcIu79aEjmly93adVxcg5wDJpkvMiwDTufEN30M8G4gGcjo1JE5jFjAcyQcRpXYkYcemA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -11290,8 +11422,7 @@
       "version": "1.2.0"
     },
     "detect-libc": {
-      "version": "1.0.3",
-      "dev": true
+      "version": "1.0.3"
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -12806,7 +12937,7 @@
         "got": "^11.8.5",
         "kpm-api-common": "^0.1.0",
         "kpm-backend-interface": "^0.1.0",
-        "node-cache": "*",
+        "node-cache": "^5.1.2",
         "openid-client": "^5.2.1",
         "pino-pretty": "^9.1.1",
         "prettier": "^2.7.1",
@@ -12870,7 +13001,8 @@
     },
     "lightningcss": {
       "version": "1.16.0",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.16.0.tgz",
+      "integrity": "sha512-5+ZS9h+xeADcJTF2oRCT3yNZBlDYyOgQSdrWNBCqsIwm8ucKbF061OBVv/WHP4Zk8FToNhwFklk/hMuOngqsIg==",
       "requires": {
         "detect-libc": "^1.0.3",
         "lightningcss-darwin-arm64": "1.16.0",
@@ -12883,9 +13015,50 @@
         "lightningcss-win32-x64-msvc": "1.16.0"
       }
     },
+    "lightningcss-darwin-arm64": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.16.0.tgz",
+      "integrity": "sha512-gIhz6eZFwsC4oVMjBGQ3QWDdLQY7vcXFyM/x91PilgHqu63B9uBa10EZA75YoTEkbKhoz0uDCqyHh/EoF1GrkQ==",
+      "optional": true
+    },
     "lightningcss-darwin-x64": {
       "version": "1.16.0",
-      "dev": true,
+      "optional": true
+    },
+    "lightningcss-linux-arm-gnueabihf": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.16.0.tgz",
+      "integrity": "sha512-oSwEbvXUPr//H/ainBRJXTxHerlheee/KgkTTmAQWiVnt8HV+bRohTBWWPBy5ZArgiGLwj7ogv45istgljPN2Q==",
+      "optional": true
+    },
+    "lightningcss-linux-arm64-gnu": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.16.0.tgz",
+      "integrity": "sha512-Drq9BSVIvmV9zsDJbCZWCulMvKMQWFIlYXPCKV/iwRj+ZAJ1BRngma0cNHB6uW7Wac8Jg04CJN5IA4ELE3J+cQ==",
+      "optional": true
+    },
+    "lightningcss-linux-arm64-musl": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.16.0.tgz",
+      "integrity": "sha512-1QXWStnTEo4RFQf0mfGhRyNUeEHilCZ0NA97XgwKwrYr/M7sYKU/1HWY00dPxFJ6GITR2pfJGo9xi3ScSSBxbA==",
+      "optional": true
+    },
+    "lightningcss-linux-x64-gnu": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.16.0.tgz",
+      "integrity": "sha512-gD2eQYD5OFs1p83R0TcMCEc5HRyJES4lR4THmclv7khm3dc9vc+2VT0kFBPxO1L2AwlZuvXaaMan7X1Ul7uSfA==",
+      "optional": true
+    },
+    "lightningcss-linux-x64-musl": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.16.0.tgz",
+      "integrity": "sha512-HJsKeYxloEvg2WCQhtYPqzZUliLu9JBJNeI5y9cPQeDR/7ayGGLbVhJaotPtzJkElOFL/SaXsS+FRuH4w+yafg==",
+      "optional": true
+    },
+    "lightningcss-win32-x64-msvc": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.16.0.tgz",
+      "integrity": "sha512-h4ayyAlOMLUHV9NdofcIu79aEjmly93adVxcg5wDJpkvMiwDTufEN30M8G4gGcjo1JE5jFjAcyQcRpXYkYcemA==",
       "optional": true
     },
     "lines-and-columns": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "npm-run-all": "^4.1.5"
   },
   "dependencies": {
-    "evolene-local-packages": "^0.1.0"
+    "evolene-local-packages": "^0.1.0",
+    "lightningcss": "^1.16.0"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
Main review question: Does the changes in the `APITeaching` type look reasonable.

Todo: 
- [x] Await stuff in parallell rather than sequentially
- [x] Cache kopps info per course (most will be reused for many users)