### PR TITLE
Structured course data for studies.

### DIFF
--- a/apis/my-studies-api/__test__/convertToCoursesProgrammes.spec.ts
+++ b/apis/my-studies-api/__test__/convertToCoursesProgrammes.spec.ts
@@ -19,27 +19,27 @@ import {
 const courseTestCases: { [index: string]: TUserCourse } = {
   "ladok2.kurser.SE.1020": {
     type: "kurser",
-    code: "SE1020",
+    course_code: "SE1020",
   },
   "ladok2.kurser.ME.2053.antagna_20222": {
     type: "kurser",
-    code: "ME2053",
+    course_code: "ME2053",
     status: "antagna",
     year: 2022,
     term: "2",
   },
   "ladok2.kurser.MF.2102.godkand": {
     type: "kurser",
-    code: "MF2102",
+    course_code: "MF2102",
     status: "godkand",
   },
   "ladok2.kurser.MF.2114": {
     type: "kurser",
-    code: "MF2114",
+    course_code: "MF2114",
   },
   "ladok2.kurser.MF.2032.registrerade_20221.1": {
     type: "kurser",
-    code: "MF2032",
+    course_code: "MF2032",
     status: "registrerade",
     year: 2022,
     term: "1",
@@ -47,7 +47,7 @@ const courseTestCases: { [index: string]: TUserCourse } = {
   },
   "ladok2.kurser.MF.2039.registrerade_20212.1": {
     type: "kurser",
-    code: "MF2039",
+    course_code: "MF2039",
     status: "registrerade",
     year: 2021,
     term: "2",
@@ -55,12 +55,12 @@ const courseTestCases: { [index: string]: TUserCourse } = {
   },
   "ladok2.kurser.ÅF.2102.godkand": {
     type: "kurser",
-    code: "ÅF2102",
+    course_code: "ÅF2102",
     status: "godkand",
   },
   "ladok2.kurser.ÅF.210v.godkand": {
     type: "kurser",
-    code: "ÅF210v",
+    course_code: "ÅF210v",
     status: "godkand",
   },
 };
@@ -68,7 +68,7 @@ const courseTestCases: { [index: string]: TUserCourse } = {
 const programmeTestCases: { [index: string]: TUserProgram } = {
   "ladok2.program.TIPDM.registrerade_20221": {
     type: "program",
-    code: "TIPDM",
+    program_code: "TIPDM",
     status: "registrerade",
     year: 2022,
     term: "1",

--- a/apis/my-studies-api/__test__/convertToCoursesProgrammes.spec.ts
+++ b/apis/my-studies-api/__test__/convertToCoursesProgrammes.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, jest, test } from "@jest/globals";
 import {
   convertToCourseObjects,
   convertToProgrammeObjects,
+  TUserCourse,
 } from "../src/apiUtils";
 
 // ladok2.kurser.SE.1020
@@ -14,7 +15,7 @@ import {
 // ladok2.kurser.ÅF.2102.godkand
 // ladok2.kurser.ÅF.210v.godkand
 
-const courseTestCases: { [index: string]: any } = {
+const courseTestCases: { [index: string]: TUserCourse } = {
   "ladok2.kurser.SE.1020": {
     type: "kurser",
     code: "SE1020",
@@ -27,7 +28,7 @@ const courseTestCases: { [index: string]: any } = {
     code_pt1: "ME",
     code_pt2: "2053",
     status: "antagna",
-    year: "2022",
+    year: 2022,
     term: "2",
   },
   "ladok2.kurser.MF.2102.godkand": {
@@ -49,7 +50,7 @@ const courseTestCases: { [index: string]: any } = {
     code_pt1: "MF",
     code_pt2: "2032",
     status: "registrerade",
-    year: "2022",
+    year: 2022,
     term: "1",
     round: "1",
   },
@@ -59,7 +60,7 @@ const courseTestCases: { [index: string]: any } = {
     code_pt1: "MF",
     code_pt2: "2039",
     status: "registrerade",
-    year: "2021",
+    year: 2021,
     term: "2",
     round: "1",
   },

--- a/apis/my-studies-api/__test__/convertToCoursesProgrammes.spec.ts
+++ b/apis/my-studies-api/__test__/convertToCoursesProgrammes.spec.ts
@@ -3,6 +3,7 @@ import {
   convertToCourseObjects,
   convertToProgrammeObjects,
   TUserCourse,
+  TUserProgram,
 } from "../src/apiUtils";
 
 // ladok2.kurser.SE.1020
@@ -64,12 +65,12 @@ const courseTestCases: { [index: string]: TUserCourse } = {
   },
 };
 
-const programmeTestCases: { [index: string]: any } = {
+const programmeTestCases: { [index: string]: TUserProgram } = {
   "ladok2.program.TIPDM.registrerade_20221": {
     type: "program",
     code: "TIPDM",
     status: "registrerade",
-    year: "2022",
+    year: 2022,
     term: "1",
   },
 };

--- a/apis/my-studies-api/__test__/convertToCoursesProgrammes.spec.ts
+++ b/apis/my-studies-api/__test__/convertToCoursesProgrammes.spec.ts
@@ -19,14 +19,10 @@ const courseTestCases: { [index: string]: TUserCourse } = {
   "ladok2.kurser.SE.1020": {
     type: "kurser",
     code: "SE1020",
-    code_pt1: "SE",
-    code_pt2: "1020",
   },
   "ladok2.kurser.ME.2053.antagna_20222": {
     type: "kurser",
     code: "ME2053",
-    code_pt1: "ME",
-    code_pt2: "2053",
     status: "antagna",
     year: 2022,
     term: "2",
@@ -34,21 +30,15 @@ const courseTestCases: { [index: string]: TUserCourse } = {
   "ladok2.kurser.MF.2102.godkand": {
     type: "kurser",
     code: "MF2102",
-    code_pt1: "MF",
-    code_pt2: "2102",
     status: "godkand",
   },
   "ladok2.kurser.MF.2114": {
     type: "kurser",
     code: "MF2114",
-    code_pt1: "MF",
-    code_pt2: "2114",
   },
   "ladok2.kurser.MF.2032.registrerade_20221.1": {
     type: "kurser",
     code: "MF2032",
-    code_pt1: "MF",
-    code_pt2: "2032",
     status: "registrerade",
     year: 2022,
     term: "1",
@@ -57,8 +47,6 @@ const courseTestCases: { [index: string]: TUserCourse } = {
   "ladok2.kurser.MF.2039.registrerade_20212.1": {
     type: "kurser",
     code: "MF2039",
-    code_pt1: "MF",
-    code_pt2: "2039",
     status: "registrerade",
     year: 2021,
     term: "2",
@@ -67,15 +55,11 @@ const courseTestCases: { [index: string]: TUserCourse } = {
   "ladok2.kurser.ÅF.2102.godkand": {
     type: "kurser",
     code: "ÅF2102",
-    code_pt1: "ÅF",
-    code_pt2: "2102",
     status: "godkand",
   },
   "ladok2.kurser.ÅF.210v.godkand": {
     type: "kurser",
     code: "ÅF210v",
-    code_pt1: "ÅF",
-    code_pt2: "210v",
     status: "godkand",
   },
 };

--- a/apis/my-studies-api/src/api.ts
+++ b/apis/my-studies-api/src/api.ts
@@ -6,7 +6,9 @@ import {
   convertToProgrammeObjects,
   getListOfCourseProgrammeNames,
   TCourseCode,
+  TProgramCode,
   TUserCourse,
+  TUserProgram,
 } from "./apiUtils";
 
 const IS_DEV = process.env.NODE_ENV !== "production";
@@ -52,7 +54,7 @@ export type TUgGroup = {
 
 export type TUserStudies = {
   courses: Record<TCourseCode, TUserCourse[]>;
-  programmes: any[]; // FIXME
+  programmes: Record<TProgramCode, TUserProgram[]>;
 };
 
 api.get("/user/:user", async (req, res: express.Response<TUserStudies>) => {
@@ -91,9 +93,18 @@ api.get("/user/:user", async (req, res: express.Response<TUserStudies>) => {
       courses[course_code] = [obj];
     }
   }
+  let programmes: { [index: TProgramCode]: TUserProgram[] } = {};
+  for (const obj of convertToProgrammeObjects(programmeNames)) {
+    let program_code = obj.code;
+    if (programmes[program_code]) {
+      programmes[program_code].push(obj);
+    } else {
+      programmes[program_code] = [obj];
+    }
+  }
 
   res.status(statusCode || 200).send({
     courses,
-    programmes: convertToProgrammeObjects(programmeNames),
+    programmes,
   });
 });

--- a/apis/my-studies-api/src/api.ts
+++ b/apis/my-studies-api/src/api.ts
@@ -86,7 +86,7 @@ api.get("/user/:user", async (req, res: express.Response<TUserStudies>) => {
 
   let courses: { [index: TCourseCode]: TUserCourse[] } = {};
   for (const obj of convertToCourseObjects(courseNames)) {
-    let course_code = obj.code;
+    let course_code = obj.course_code;
     if (courses[course_code]) {
       courses[course_code].push(obj);
     } else {
@@ -95,7 +95,7 @@ api.get("/user/:user", async (req, res: express.Response<TUserStudies>) => {
   }
   let programmes: { [index: TProgramCode]: TUserProgram[] } = {};
   for (const obj of convertToProgrammeObjects(programmeNames)) {
-    let program_code = obj.code;
+    let program_code = obj.program_code;
     if (programmes[program_code]) {
       programmes[program_code].push(obj);
     } else {

--- a/apis/my-studies-api/src/apiUtils.ts
+++ b/apis/my-studies-api/src/apiUtils.ts
@@ -41,8 +41,6 @@ export type TCourseCode = string;
 export type TUserCourse = {
   type: string;
   code: TCourseCode;
-  code_pt1: string;
-  code_pt2: string;
   status?: "antagna" | "godkand" | "registrerade";
   year?: number;
   term?: "1" | "2";
@@ -60,8 +58,6 @@ export function convertToCourseObjects(inp: string[]): TUserCourse[] {
     return {
       type,
       code: `${code_pt1}${code_pt2}`,
-      code_pt1,
-      code_pt2,
       status: cstatus,
       year: parseInt(cyear) || undefined,
       term: cterm,

--- a/apis/my-studies-api/src/apiUtils.ts
+++ b/apis/my-studies-api/src/apiUtils.ts
@@ -40,7 +40,7 @@ export function getListOfCourseProgrammeNames(inp: string[]) {
 export type TCourseCode = string;
 export type TUserCourse = {
   type: string;
-  code: TCourseCode;
+  course_code: TCourseCode;
   status?: "antagna" | "godkand" | "registrerade";
   year?: number;
   term?: "1" | "2";
@@ -57,7 +57,7 @@ export function convertToCourseObjects(inp: string[]): TUserCourse[] {
     const { type, code_pt1, code_pt2, cstatus, cyear, cterm, cterm_pt2 } = o;
     return {
       type,
-      code: `${code_pt1}${code_pt2}`,
+      course_code: `${code_pt1}${code_pt2}`,
       status: cstatus,
       year: parseInt(cyear) || undefined,
       term: cterm,
@@ -69,7 +69,7 @@ export function convertToCourseObjects(inp: string[]): TUserCourse[] {
 export type TProgramCode = string;
 export type TUserProgram = {
   type: "program";
-  code: TProgramCode;
+  program_code: TProgramCode;
   status?: "antagna" | "godkand" | "registrerade";
   year?: number;
   term?: "1" | "2";
@@ -77,15 +77,15 @@ export type TUserProgram = {
 
 export function convertToProgrammeObjects(inp: string[]): TUserProgram[] {
   const progrRegex =
-    /^ladok2\.(?<type>program)\.(?<code_pt1>[^\.]*)\.((?<pstatus>[^\._]*)_(?<pyear>\d{4})(?<pterm>\d{1}))$/i;
+    /^ladok2\.(?<type>program)\.(?<code>[^\.]*)\.((?<pstatus>[^\._]*)_(?<pyear>\d{4})(?<pterm>\d{1}))$/i;
   const tmpJson = inp
     ?.map((o) => o.match(progrRegex)?.groups)
     .filter((o) => o && o.type === "program");
   return tmpJson?.map((o: any) => {
-    const { type, code_pt1, pstatus, pyear, pterm } = o;
+    const { type, code, pstatus, pyear, pterm } = o;
     return {
       type,
-      code: code_pt1,
+      program_code: code,
       status: pstatus,
       year: parseInt(pyear) || undefined,
       term: pterm,

--- a/apis/my-studies-api/src/apiUtils.ts
+++ b/apis/my-studies-api/src/apiUtils.ts
@@ -37,7 +37,19 @@ export function getListOfCourseProgrammeNames(inp: string[]) {
   };
 }
 
-export function convertToCourseObjects(inp: string[]) {
+export type TCourseCode = string;
+export type TUserCourse = {
+  type: string;
+  code: TCourseCode;
+  code_pt1: string;
+  code_pt2: string;
+  status?: "antagna" | "godkand" | "registrerade";
+  year?: number;
+  term?: "1" | "2";
+  round?: string;
+};
+
+export function convertToCourseObjects(inp: string[]): TUserCourse[] {
   const courseRegex =
     /^ladok2\.(?<type>kurser)\.(?<code_pt1>[^\.]*)\.(?<code_pt2>[^\.]*)(\.(?<cstatus>[^\._]*)(_(?<cyear>\d{4})(?<cterm>\d{1})(\.(?<cterm_pt2>\d{1}))?)?)?$/i;
   const tmpJson = inp
@@ -51,7 +63,7 @@ export function convertToCourseObjects(inp: string[]) {
       code_pt1,
       code_pt2,
       status: cstatus,
-      year: cyear,
+      year: parseInt(cyear) || undefined,
       term: cterm,
       round: cterm_pt2, // QUESTION: Is this really round id or perhaps section or something similar? Matches the last number of "registrerade_20221.1"
     };

--- a/apis/my-studies-api/src/apiUtils.ts
+++ b/apis/my-studies-api/src/apiUtils.ts
@@ -66,7 +66,16 @@ export function convertToCourseObjects(inp: string[]): TUserCourse[] {
   });
 }
 
-export function convertToProgrammeObjects(inp: string[]) {
+export type TProgramCode = string;
+export type TUserProgram = {
+  type: "program";
+  code: TProgramCode;
+  status?: "antagna" | "godkand" | "registrerade";
+  year?: number;
+  term?: "1" | "2";
+};
+
+export function convertToProgrammeObjects(inp: string[]): TUserProgram[] {
   const progrRegex =
     /^ladok2\.(?<type>program)\.(?<code_pt1>[^\.]*)\.((?<pstatus>[^\._]*)_(?<pyear>\d{4})(?<pterm>\d{1}))$/i;
   const tmpJson = inp
@@ -78,7 +87,7 @@ export function convertToProgrammeObjects(inp: string[]) {
       type,
       code: code_pt1,
       status: pstatus,
-      year: pyear,
+      year: parseInt(pyear) || undefined,
       term: pterm,
     };
   });

--- a/kpm/kpm-backend-interface/src/index.ts
+++ b/kpm/kpm-backend-interface/src/index.ts
@@ -7,7 +7,7 @@ export type APITeaching = {
 };
 
 export type APIStudies = {
-  courses: TStudiesCourse[];
+  courses: Record<TCourseCode, TStudiesCourse>;
   programmes: TStudiesProgramme[];
 };
 
@@ -44,14 +44,18 @@ export type TTeachingRole = {
 };
 
 export type TStudiesCourse = {
-  type: "kurser";
-  code: string;
-  code_pt1: string;
-  code_pt2: string;
+  course_code: TCourseCode;
+  title: { sv: string; en: string };
+  credits: number;
+  creditUnitAbbr: string; // usually "hp", check other values!
+  roles: TStuidesCourseInner[];
+  rooms: TCanvasRoom[];
+};
+export type TStuidesCourseInner = {
   status?: "antagna" | "godkand" | "registrerade";
-  year: string;
-  term: "1" | "2" | "3" | "4";
-  round: "1" | "2";
+  year?: number;
+  term?: "1" | "2";
+  round?: string;
 };
 
 export type TStudiesProgramme = {

--- a/kpm/kpm-backend-interface/src/index.ts
+++ b/kpm/kpm-backend-interface/src/index.ts
@@ -8,10 +8,11 @@ export type APITeaching = {
 
 export type APIStudies = {
   courses: Record<TCourseCode, TStudiesCourse>;
-  programmes: TStudiesProgramme[];
+  programmes: Record<TProgrammeCode, TStudiesProgramme[]>;
 };
 
 export type TCourseCode = string;
+export type TProgrammeCode = string;
 
 // QUESTION: Should we import types from the API-packages? Should these types be moved to separate packages?
 // Same as type Link in my-canvas-rooms-api/src/api.ts
@@ -61,7 +62,7 @@ export type TStuidesCourseInner = {
 export type TStudiesProgramme = {
   type: "program";
   code: string;
-  status?: "registrerade" | "antagna" | "godkand";
-  year: string;
-  term: "1" | "2" | "3" | "4";
+  status?: "antagna" | "godkand" | "registrerade";
+  year?: number;
+  term?: "1" | "2";
 };

--- a/kpm/kpm-backend-interface/src/index.ts
+++ b/kpm/kpm-backend-interface/src/index.ts
@@ -8,11 +8,11 @@ export type APITeaching = {
 
 export type APIStudies = {
   courses: Record<TCourseCode, TStudiesCourse>;
-  programmes: Record<TProgrammeCode, TStudiesProgramme[]>;
+  programmes: Record<TProgramCode, TStudiesProgramme[]>;
 };
 
 export type TCourseCode = string;
-export type TProgrammeCode = string;
+export type TProgramCode = string;
 
 // QUESTION: Should we import types from the API-packages? Should these types be moved to separate packages?
 // Same as type Link in my-canvas-rooms-api/src/api.ts
@@ -61,7 +61,7 @@ export type TStuidesCourseInner = {
 
 export type TStudiesProgramme = {
   type: "program";
-  code: string;
+  program_code: string;
   status?: "antagna" | "godkand" | "registrerade";
   year?: number;
   term?: "1" | "2";

--- a/kpm/kpm-backend/src/api.ts
+++ b/kpm/kpm-backend/src/api.ts
@@ -102,8 +102,6 @@ api.get("/teaching", async (req, res, next) => {
 export type TApiUserCourse = {
   type: "kurser";
   code: TCourseCode;
-  code_pt1: string;
-  code_pt2: string;
   status?: "antagna" | "godkand" | "registrerade";
   year?: number;
   term?: "1" | "2";

--- a/kpm/kpm-backend/src/api.ts
+++ b/kpm/kpm-backend/src/api.ts
@@ -10,7 +10,7 @@ import {
   TTeachingRole,
   TCourseCode,
   TStudiesCourse,
-  TProgrammeCode,
+  TProgramCode,
 } from "kpm-backend-interface";
 
 const MY_CANVAS_ROOMS_API_URI =
@@ -102,7 +102,7 @@ api.get("/teaching", async (req, res, next) => {
 // Copied from my-studies-api:
 export type TApiUserCourse = {
   type: "kurser";
-  code: TCourseCode;
+  course_code: TCourseCode;
   status?: "antagna" | "godkand" | "registrerade";
   year?: number;
   term?: "1" | "2";
@@ -111,7 +111,7 @@ export type TApiUserCourse = {
 // Copied from my-studies-api:
 export type TUserProgramme = {
   type: "program";
-  code: TProgrammeCode;
+  program_code: TProgramCode;
   status?: "antagna" | "godkand" | "registrerade";
   year?: number;
   term?: "1" | "2";
@@ -119,7 +119,7 @@ export type TUserProgramme = {
 // Copied from my-studies-api:
 export type TApiUserStudies = {
   courses: Record<TCourseCode, TApiUserCourse[]>;
-  programmes: Record<TProgrammeCode, TUserProgramme[]>;
+  programmes: Record<TProgramCode, TUserProgramme[]>;
 };
 
 api.get("/studies", async (req, res: express.Response<APIStudies>, next) => {

--- a/kpm/kpm-backend/src/api.ts
+++ b/kpm/kpm-backend/src/api.ts
@@ -10,6 +10,7 @@ import {
   TTeachingRole,
   TCourseCode,
   TStudiesCourse,
+  TProgrammeCode,
 } from "kpm-backend-interface";
 
 const MY_CANVAS_ROOMS_API_URI =
@@ -98,7 +99,7 @@ api.get("/teaching", async (req, res, next) => {
   }
 });
 
-// Types copied from my-studies-api:
+// Copied from my-studies-api:
 export type TApiUserCourse = {
   type: "kurser";
   code: TCourseCode;
@@ -107,9 +108,18 @@ export type TApiUserCourse = {
   term?: "1" | "2";
   round?: string;
 };
+// Copied from my-studies-api:
+export type TUserProgramme = {
+  type: "program";
+  code: TProgrammeCode;
+  status?: "antagna" | "godkand" | "registrerade";
+  year?: number;
+  term?: "1" | "2";
+};
+// Copied from my-studies-api:
 export type TApiUserStudies = {
   courses: Record<TCourseCode, TApiUserCourse[]>;
-  programmes: any[]; // FIXME
+  programmes: Record<TProgrammeCode, TUserProgramme[]>;
 };
 
 api.get("/studies", async (req, res: express.Response<APIStudies>, next) => {

--- a/kpm/kpm-frontend/src/panes/studies.tsx
+++ b/kpm/kpm-frontend/src/panes/studies.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { useLoaderData } from "react-router-dom";
 import { APIStudies } from "kpm-backend-interface";
 import { MenuPane } from "../components/menu";
+import { CanvasRoomShortList } from "./teaching";
 
 import "./studies.scss";
 
@@ -19,25 +20,21 @@ export function Studies() {
     <MenuPane>
       <h2>Studies</h2>
       <ul className="kpm-studies">
-        {courses?.map((course) => {
-          const { code, status, year } = course ?? {};
-          const key = `${code}-${year}`;
-          return (
-            <Course key={key} courseCode={code} year={year} status={status} />
-          );
+        {Object.entries(courses)?.map((course_code, course) => {
+          return <Course courseCode={course_code} course={course} />;
         })}
       </ul>
     </MenuPane>
   );
 }
 
-function Course({ courseCode, year, status }: any) {
+function Course({ courseCode, course }: any) {
   return (
     <li className="kpm-studies-course">
-      <h2>{courseCode}</h2>
-      <h3>
-        {year} | {status}
-      </h3>
+      <h2>
+        {courseCode} {course.title.sv} {course.credits} {course.creditUnitAbbr}
+      </h2>
+      <CanvasRoomShortList rooms={course.rooms} />
     </li>
   );
 }

--- a/kpm/kpm-frontend/src/panes/teaching.tsx
+++ b/kpm/kpm-frontend/src/panes/teaching.tsx
@@ -128,8 +128,8 @@ function Course({ courseCode, course }: any) {
 type TArgsCanvasRoomXXXList = {
   rooms: TCanvasRoom[];
 };
-
-function CanvasRoomShortList({ rooms }: TArgsCanvasRoomXXXList) {
+// TODO: Move to components?  Or should the rooms in studies really be different?
+export function CanvasRoomShortList({ rooms }: TArgsCanvasRoomXXXList) {
   return (
     <ul>
       {rooms.map((room: TCanvasRoom) => {


### PR DESCRIPTION
* Changed api return structure in my-studies-api
* Changed api return structure for studies in kpm-backend to resemble the teaching structure (mention each course once).
* Document some endpoint return types with the generic parameter of `express.Response<T>`.