### PR TITLE
Implement kpm-backend wrapper for groups.

### DIFF
--- a/kpm/kpm-backend-interface/src/index.ts
+++ b/kpm/kpm-backend-interface/src/index.ts
@@ -66,3 +66,13 @@ export type TStudiesProgramme = {
   year?: number;
   term?: "1" | "2";
 };
+
+export type APIGroups = {
+  groups: TGroup[];
+  group_search_url: string;
+};
+export type TGroup = {
+  name: string;
+  url: string;
+  stared: boolean;
+};

--- a/kpm/kpm-backend/.env.in
+++ b/kpm/kpm-backend/.env.in
@@ -19,3 +19,7 @@ CANVAS_API_TOKEN=
 
 # String used to encode/decode session cookies
 SESSION_SECRET=
+
+# How to access things that is still maintained in KTH Social.
+SOCIAL_USER_URI=https://www.kth.se/social/user
+SOCIAL_KEY=


### PR DESCRIPTION
New required settings in kpm-backend:

```sh
# How to access things that is still maintained in KTH Social.
SOCIAL_USER_URI=https://www.kth.se/social/user
SOCIAL_KEY=
```