### PR TITLE
Fix kpm so it doesn't cover the full page

### DIFF
--- a/kpm/kpm-frontend/src/app.scss
+++ b/kpm/kpm-frontend/src/app.scss
@@ -6,7 +6,7 @@
   top: 0;
   left: 0;
   right: 0;
-  bottom: 0;
+  bottom: auto;
   z-index: 999;
 
   display: flex;

--- a/kpm/kpm-frontend/src/app.scss
+++ b/kpm/kpm-frontend/src/app.scss
@@ -2,6 +2,7 @@
 @use "./stylesReset.scss";
 
 #kpm-6cf53 {
+  pointer-events: none;
   position: fixed;
   top: 0;
   left: 0;
@@ -15,6 +16,7 @@
 }
 
 #kpm-6cf53 .kpm-menu {
+  pointer-events: all;
   background-color: var(--kpmMenuBg);
   color: var(--kpmMenuText);
   width: 100%;
@@ -90,7 +92,19 @@
 
 // Global styling
 #kpm-6cf53 .kpm-modal {
+  pointer-events: all;
   max-width: 1200px;
+}
+
+#kpm-6cf53 .kpm-modal-backdrop {
+  pointer-events: all;
+  position: absolute;
+  z-index: -1;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.45));
 }
 
 #kpm-6cf53 .kpm-row {

--- a/kpm/kpm-frontend/src/app.scss
+++ b/kpm/kpm-frontend/src/app.scss
@@ -7,7 +7,7 @@
   top: 0;
   left: 0;
   right: 0;
-  bottom: auto;
+  bottom: 0;
   z-index: 999;
 
   display: flex;

--- a/kpm/kpm-frontend/src/components/menu.scss
+++ b/kpm/kpm-frontend/src/components/menu.scss
@@ -1,13 +1,3 @@
-#kpm-6cf53 .kpm-modal-backdrop {
-  position: absolute;
-  z-index: -1;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(rgba(0, 0, 0, 0.25), rgba(0, 0, 0, 0.45));
-}
-
 #kpm-6cf53 .KpmModalBackdropAnim {
   &-enter {
     opacity: 0;

--- a/packages/kpm-ug-rest-client/src/ugRestClient.ts
+++ b/packages/kpm-ug-rest-client/src/ugRestClient.ts
@@ -82,7 +82,9 @@ export class UGRestClient {
     const perf1 = Date.now();
     // We use OAuth flow "Client Credentials" to receive an access token
     // This token is then passed to UG REST API using client.requestResource.
-    const issuer = (await Issuer.discover(this._authServerDiscoveryURI).catch(discoverErr)) as Issuer<BaseClient>;
+    const issuer = (await Issuer.discover(this._authServerDiscoveryURI).catch(
+      discoverErr
+    )) as Issuer<BaseClient>;
 
     const grantTypes = issuer.metadata.grant_types_supported as string[];
     assert(
@@ -111,10 +113,12 @@ export class UGRestClient {
     }
 
     const client = (await this.getClient().catch(getClientErr)) as BaseClient;
-    const accessToken = (await client.grant({
-      grant_type: "client_credentials",
-      scope: "openid",
-    }).catch(getCredentialsErr)) as TokenSet;
+    const accessToken = (await client
+      .grant({
+        grant_type: "client_credentials",
+        scope: "openid",
+      })
+      .catch(getCredentialsErr)) as TokenSet;
     assert(
       typeof accessToken.access_token === "string",
       "No access token provided by auth server"


### PR DESCRIPTION
This PR fixes the `inset` (top, bottom, left, right) CSS properties so that KPM does not cover the full page

(Note: this PR might include more small CSS fixes)