### PR TITLE
Don't push entries to nav stack when navigating in menu

### DIFF
--- a/kpm/kpm-frontend/src/Menu.tsx
+++ b/kpm/kpm-frontend/src/Menu.tsx
@@ -46,7 +46,7 @@ export function Menu({ hasStudies, hasTeaching }: any) {
 
   return (
     <React.Fragment>
-      <MenuPaneBackdrop visible={hasMatch} onClose={() => navigate("/")} />
+      <MenuPaneBackdrop visible={hasMatch} onClose={() => navigate(-1)} />
       <nav ref={menuRef} className={cls}>
         <ul>
           <li className="kpm-mobile-menu kpm-mobile">

--- a/kpm/kpm-frontend/src/components/links.tsx
+++ b/kpm/kpm-frontend/src/components/links.tsx
@@ -4,15 +4,20 @@ import { NavLink, useNavigate, useLocation } from "react-router-dom";
 export function ToggleNavLink({ children, to, onClick, ...props }: any) {
   const navigate = useNavigate();
   const location = useLocation();
-  const isOpen = `/${to}` === location.pathname;
+  const thisIsOpen = `/${to}` === location.pathname;
+  const isInRoot = "/" === location.pathname;
 
   return (
     <NavLink
       to={to}
       onClick={(e) => {
-        if (!isOpen) return;
         e.preventDefault();
-        navigate("/");
+        if (thisIsOpen) {
+          navigate("/", { replace: true });
+          return;
+        }
+        // Another pane is open so we replace nav history
+        navigate(to, { replace: !isInRoot });
       }}
       {...props}
     >

--- a/kpm/kpm-frontend/src/components/links.tsx
+++ b/kpm/kpm-frontend/src/components/links.tsx
@@ -5,7 +5,7 @@ export function ToggleNavLink({ children, to, onClick, ...props }: any) {
   const navigate = useNavigate();
   const location = useLocation();
   const thisIsOpen = `/${to}` === location.pathname;
-  const isInRoot = "/" === location.pathname;
+  const isInRoot = "/" === location.pathname || "" === location.pathname;
 
   return (
     <NavLink
@@ -13,7 +13,7 @@ export function ToggleNavLink({ children, to, onClick, ...props }: any) {
       onClick={(e) => {
         e.preventDefault();
         if (thisIsOpen) {
-          navigate("/", { replace: true });
+          navigate(-1);
           return;
         }
         // Another pane is open so we replace nav history

--- a/kpm/kpm-frontend/src/components/menu.tsx
+++ b/kpm/kpm-frontend/src/components/menu.tsx
@@ -127,7 +127,7 @@ export function MenuPane({
             <h2>{i18n("Your session has expired")}</h2>
             <LoginWidget
               onDismiss={() => {
-                navigate("/");
+                navigate(-1);
               }}
             />
           </div>
@@ -159,7 +159,7 @@ export function MenuPaneWrapper({ nodeRef, className, children }: any) {
           // NOTE: This should really listen to transitionEnd
           // but this is okay and doubles as fallback
           setTimeout(() => {
-            navigate("/");
+            navigate(-1);
           }, 310);
         }}
       >


### PR DESCRIPTION
Avoid creating a long navigation history when interacting with the menu.

- Closing a pane should pop the entry in nav stack
- Switching pane should replace the entry in nav stack
- Clicking background should pop entry in nav stack
