### PR TITLE
Improve dropdown

### DIFF
--- a/kpm/kpm-frontend/src/components/groups.tsx
+++ b/kpm/kpm-frontend/src/components/groups.tsx
@@ -64,6 +64,7 @@ export function DropdownMenuGroup({
   isOpenRef.current = open;
   useDropdownToggleListener(
     detailsRef,
+    summaryRef,
     eventListenersSetRef,
     isOpenRef,
     setOpen
@@ -114,6 +115,7 @@ const KEY_ESC = 27;
 
 function useDropdownToggleListener(
   detailsRef: RefObject<HTMLElement | null>,
+  summaryRef: RefObject<HTMLElement | null>,
   eventListenersSetRef: MutableRefObject<boolean | null>,
   isOpenRef: RefObject<boolean>,
   setOpen: Function
@@ -125,11 +127,19 @@ function useDropdownToggleListener(
       setOpen(false);
     }
 
-    // Only open if ENTER is fired when focus is on or in <details>
-    if (detailsRef.current?.contains(e.target)) {
-      console.log("Key Down", e);
+    // Close on ENTER outside dropdown if open
+    if (
+      e.which === KEY_ENTER &&
+      isOpenRef.current &&
+      !detailsRef.current?.contains(e.target)
+    ) {
+      e.preventDefault();
+      setOpen(false);
+    }
 
-      if (e.which === KEY_ENTER) {
+    // Only toggle if ENTER is fired when on or in <summary>
+    if (e.which === KEY_ENTER) {
+      if (summaryRef.current?.contains(e.target)) {
         e.preventDefault();
         setOpen(!isOpenRef.current);
       }
@@ -137,15 +147,20 @@ function useDropdownToggleListener(
   }
 
   function didClick(e: any) {
-    if (
-      //detailsRef.current === e.target ||
-      detailsRef.current?.contains(e.target)
-    ) {
+    // Toggle when clicking summary
+    if (summaryRef.current?.contains(e.target)) {
       const currentOpen = isOpenRef.current;
+      // Click triggers <detail> open so we need the setTimeout workaround
       setTimeout(() => {
         e.preventDefault();
         setOpen(!currentOpen);
       });
+    }
+
+    // Close if open and clicking somewhere else than dropdown
+    if (isOpenRef.current && !detailsRef.current?.contains(e.target)) {
+      e.preventDefault();
+      setOpen(false);
     }
   }
 

--- a/kpm/kpm-frontend/src/components/groups.tsx
+++ b/kpm/kpm-frontend/src/components/groups.tsx
@@ -30,7 +30,6 @@ type TDropdownMenuGroupProps = {
   revealUp?: boolean;
   alignRight?: boolean;
   defaultOpen?: boolean;
-  modal?: boolean; // Will not allow other interactions until closed
 };
 
 export function DropdownMenuGroup({
@@ -40,7 +39,6 @@ export function DropdownMenuGroup({
   revealUp = false,
   alignRight = false,
   defaultOpen = false,
-  modal = false,
 }: TDropdownMenuGroupProps) {
   const [open, setOpen] = useState(defaultOpen);
   const [dropdownStyle, setDropdownStyle]: [TStyle, Function] =
@@ -76,10 +74,6 @@ export function DropdownMenuGroup({
     cls += ` ${className}`;
   }
 
-  const doCloseOnBackropClick = () => {
-    setOpen(false);
-  };
-
   const _inner = (
     <div style={dropdownStyle} className="kpm-link-list">
       <ul ref={dropdownRef}>{children}</ul>
@@ -89,40 +83,8 @@ export function DropdownMenuGroup({
   return (
     <details ref={detailsRef} className={cls} open={open}>
       <summary ref={summaryRef}>{title}</summary>
-      {modal ? (
-        <ModalBackdrop onClose={doCloseOnBackropClick}>{_inner}</ModalBackdrop>
-      ) : (
-        _inner
-      )}
+      {_inner}
     </details>
-  );
-}
-
-type TModalBackdropProps = {
-  children?: JSX.Element;
-  onClose?: () => void;
-};
-function ModalBackdrop({ children, onClose }: TModalBackdropProps) {
-  const [oldOverflow, setOldOverflow] = useState("");
-
-  useEffect(() => {
-    setOldOverflow(document.body.style.overflow);
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = oldOverflow;
-    };
-  }, []);
-
-  return (
-    <div
-      className="kpm-dropdown-backdrop"
-      tabIndex={-1}
-      onClick={() => {
-        onClose && onClose();
-      }}
-    >
-      {children}
-    </div>
   );
 }
 


### PR DESCRIPTION
Changed interaction with dropdown based on feedback:
- don't toggle on focus
- open on enter or click
- close on escape (anywhere)
- close on click or enter (outside dropdown)

Moved code to hook and removed the unused modal feature. 