### PR TITLE
Fix routing when on a page with a hash route

### DIFF
--- a/kpm/kpm-frontend/src/app.tsx
+++ b/kpm/kpm-frontend/src/app.tsx
@@ -24,7 +24,6 @@ declare global {
 function createRouter({ ...props }: TRouterProps) {
   return createHashRouter([
     {
-      path: "/",
       element: <Menu {...props} />,
       errorElement: <Menu {...props} />,
       children: getRoutes({ ...props }).map((route) => ({

--- a/kpm/kpm-frontend/src/components/links.tsx
+++ b/kpm/kpm-frontend/src/components/links.tsx
@@ -1,11 +1,14 @@
 import * as React from "react";
 import { NavLink, useNavigate, useLocation } from "react-router-dom";
+import { getRoutes } from "../routes";
 
 export function ToggleNavLink({ children, to, onClick, ...props }: any) {
   const navigate = useNavigate();
   const location = useLocation();
   const thisIsOpen = `/${to}` === location.pathname;
-  const isInRoot = "/" === location.pathname || "" === location.pathname;
+  const isInRoot = !getRoutes().some(
+    (r) => typeof r.path === "string" && location.pathname.startsWith(r.path)
+  );
 
   return (
     <NavLink


### PR DESCRIPTION
This PR fixes two issues when using hash routing on a page. There are two use case:

- anchor links within a page
- tab navigation in Canvas (which uses hash routing)

We achieve this by:
- showing menu bar regardless of what hash we currently are on
- going back to previous hash route when closing the menu