### PR TITLE
Mute CORS errors and make sure they send the correct statusCode

### DIFF
--- a/kpm/kpm-backend-interface/src/index.ts
+++ b/kpm/kpm-backend-interface/src/index.ts
@@ -1,5 +1,7 @@
 export type TGotErrType = "NotAvailable" | "BadResponse" | "TimeoutError";
 
+export type TCorsError = "InvalidOrigin";
+
 export type TSessionUser = {
   kthid: string;
   display_name: string;

--- a/packages/kpm-api-common/src/errors.ts
+++ b/packages/kpm-api-common/src/errors.ts
@@ -5,7 +5,7 @@ import { v4 as uuid } from "uuid";
  *
  * Use generic T to define the different error types you have. This helps enforcing complete error handling.
  */
-type TErrorName = "EndpointError" | "AuthError";
+type TErrorName = "EndpointError" | "AuthError" | "CorsError";
 type TOperationalError<ErrType> = {
   name: TErrorName;
   statusCode: number;

--- a/packages/kpm-api-common/src/index.ts
+++ b/packages/kpm-api-common/src/index.ts
@@ -27,7 +27,12 @@ export function errorHandler(
   next: NextFunction
 ) {
   let statusCode: number;
-  let name: "EndpointError" | "AuthError" | "RecoverableError" | "Error";
+  let name:
+    | "EndpointError"
+    | "AuthError"
+    | "RecoverableError"
+    | "CorsError"
+    | "Error";
   let type: string | undefined;
   let message: string;
   let details: string | null | undefined;


### PR DESCRIPTION
[403 Forbidden](https://en.wikipedia.org/wiki/HTTP_403)
The request contained valid data and was understood by the server, but the server is refusing action. This may be due to the user not having the necessary permissions for a resource or needing an account of some sort, or attempting a prohibited action (e.g. creating a duplicate record where only one is allowed). This code is also typically used if the request provided authentication by answering the WWW-Authenticate header field challenge, but the server did not accept that authentication. The request should not be repeated.

I added "CorsError" as possible error name because it is such a specific kind of error of high magnitude.