### PR TITLE
Package and decorate error in memoizer for better general error logging

### DIFF
--- a/kpm/kpm-backend/src/api/common.ts
+++ b/kpm/kpm-backend/src/api/common.ts
@@ -141,7 +141,6 @@ export const getCourseInfo = memoized<TKoppsCourseInfo>({
           responseType: "json",
         }
       )
-
       .then((r) =>
         r.statusCode >= 200 && r.statusCode < 300 ? r.body : undefined
       );

--- a/kpm/kpm-backend/src/api/commonCache.ts
+++ b/kpm/kpm-backend/src/api/commonCache.ts
@@ -63,7 +63,7 @@ export function memoized<T extends TCacheable>({
 
     // Cache miss, calculate value, store and return
     const newValue: T | undefined = await fn(key).catch((err: any) => {
-      err.details = { key };
+      err.details = { ...err.details, memoized_key: key };
       log.error(err);
       return undefined;
     });


### PR DESCRIPTION
We could improve error handling in the actual resolver that causes the error, but this is the general error handler and will do for now.