### PR TITLE
Sort courses in teaching alphabetically by course code (for now)

### DIFF
--- a/kpm/kpm-backend/src/api/teaching.ts
+++ b/kpm/kpm-backend/src/api/teaching.ts
@@ -70,9 +70,9 @@ export async function teachingApiHandler(
       };
     }
 
-    // Sort courses alphabetically by course code
+    // Sort courses alphabetically by key (course_code)
     const tmp = Object.entries(courses).sort(
-      (a, b) => (a < b && -1) || (a > b && 1) || 0
+      ([a], [b]) => (a < b && -1) || (a > b && 1) || 0
     );
     courses = Object.fromEntries(tmp);
 

--- a/kpm/kpm-backend/src/api/teaching.ts
+++ b/kpm/kpm-backend/src/api/teaching.ts
@@ -70,6 +70,12 @@ export async function teachingApiHandler(
       };
     }
 
+    // Sort courses alphabetically by course code
+    const tmp = Object.entries(courses).sort(
+      (a, b) => (a < b && -1) || (a > b && 1) || 0
+    );
+    courses = Object.fromEntries(tmp);
+
     res.send({ courses });
   } catch (err) {
     next(err);


### PR DESCRIPTION
A teacher asked what magic order the courses are sorted by, noting it was impossible to figure out. As it turns out, we had random order. Changing this to order by course code. This should improve discovery when browsing the list.