### PR TITLE
Use accept-language.

### DIFF
--- a/kpm/kpm-backend/src/api/common.ts
+++ b/kpm/kpm-backend/src/api/common.ts
@@ -44,12 +44,14 @@ export function sessionUser(session: SessionData): TSessionUser {
 
 export async function getSocial<T>(
   user: TSessionUser,
-  endpoint: string
+  endpoint: string,
+  language: string | undefined
 ): Promise<T> {
   return await got
     .get<T>(`${SOCIAL_USER_API}/${user.kthid}/${endpoint}.json`, {
       headers: {
         authorization: SOCIAL_KEY,
+        "Accept-Language": language || "en",
       },
       responseType: "json",
     })

--- a/kpm/kpm-backend/src/api/groups.ts
+++ b/kpm/kpm-backend/src/api/groups.ts
@@ -10,7 +10,10 @@ export async function groupsApiHandler(
 ) {
   try {
     const user = sessionUser(req.session);
-    const data = await getSocial<APIGroups>(user, "groups").catch(socialErr);
+    const lang = req.headers["accept-language"];
+    const data = await getSocial<APIGroups>(user, "groups", lang).catch(
+      socialErr
+    );
     res.send(data!);
   } catch (err) {
     next(err);

--- a/kpm/kpm-backend/src/api/programmes.ts
+++ b/kpm/kpm-backend/src/api/programmes.ts
@@ -10,7 +10,8 @@ export async function programmesApiHandler(
 ) {
   try {
     const user = sessionUser(req.session);
-    const data = await getSocial<APIProgrammes>(user, "programmes").catch(
+    const lang = req.headers["accept-language"];
+    const data = await getSocial<APIProgrammes>(user, "programmes", lang).catch(
       socialErr
     );
     res.send(data!);

--- a/kpm/kpm-backend/src/api/services.ts
+++ b/kpm/kpm-backend/src/api/services.ts
@@ -10,7 +10,8 @@ export async function servicesApiHandler(
 ) {
   try {
     const user = sessionUser(req.session);
-    const data = await getSocial<APIServices>(user, "services").catch(
+    const lang = req.headers["accept-language"];
+    const data = await getSocial<APIServices>(user, "services", lang).catch(
       socialErr
     );
     res.send(data!);

--- a/kpm/kpm-backend/src/session.ts
+++ b/kpm/kpm-backend/src/session.ts
@@ -65,9 +65,12 @@ export async function sessionApiHandler(
   try {
     const user = sessionUser(req.session);
     if (user) {
-      let notes = await getSocial<NumNotes>(user, "notifications/count").catch(
-        socialErr
-      );
+      const lang = req.headers["accept-language"];
+      let notes = await getSocial<NumNotes>(
+        user,
+        "notifications/count",
+        lang
+      ).catch(socialErr);
       logger.info({ notes, kthid: user.kthid }, "Notes according to social");
       user.numNewNotifications = notes?.new;
     }

--- a/kpm/kpm-frontend/src/panes/services.tsx
+++ b/kpm/kpm-frontend/src/panes/services.tsx
@@ -116,7 +116,7 @@ export function Services() {
                   {studentlinks?.map((link) => (
                     <li key={link.url}>
                       <h4>
-                        <a href={link.url}>{i18n(link.name)}</a>
+                        <a href={link.url}>{link.name}</a>
                       </h4>
                       {link.info && <p>{link.info}</p>}
                     </li>
@@ -140,7 +140,7 @@ export function Services() {
               {servicelinks?.map((links) => (
                 <li key={links.url}>
                   <h4>
-                    <a href={links.url}>{i18n(links.name)}</a>
+                    <a href={links.url}>{links.name}</a>
                   </h4>
                 </li>
               ))}

--- a/kpm/kpm-frontend/src/panes/utils.ts
+++ b/kpm/kpm-frontend/src/panes/utils.ts
@@ -100,6 +100,7 @@ export async function fetchApi(
     credentials: "include",
     headers: {
       Accept: "application/json",
+      "Accept-Language": window.__kpmSettings__?.["lang"] || "en",
       ...headers,
     },
     ...otherOptions,


### PR DESCRIPTION
Set accept-language on all backend requests in frontent, and propagate that header to any requests to social in the backend.

This fixes the translations for service links.