### PR TITLE
Include all relevant registration codes.

### DIFF
--- a/apis/my-canvas-rooms-api/__test__/test.spec.ts
+++ b/apis/my-canvas-rooms-api/__test__/test.spec.ts
@@ -196,7 +196,7 @@ describe("Known room formats data can be parsed", () => {
         "link": {
           "favorite": false,
           "name": "DD1320/DD1325 HT21-1 Tillämpad datalogi",
-          "registrationCode": "50104",
+          "registrationCode": "50104/51218/52100",
           "startTerm": "20212",
           "state": "available",
           "type": "course",
@@ -223,7 +223,7 @@ describe("Known room formats data can be parsed", () => {
         "link": {
           "favorite": false,
           "name": "KH0022/KH0025 HT21/VT22 Fysik för basår I",
-          "registrationCode": "61340",
+          "registrationCode": "51732/61340",
           "startTerm": "20221",
           "state": "available",
           "type": "course",

--- a/apis/my-canvas-rooms-api/src/api.ts
+++ b/apis/my-canvas-rooms-api/src/api.ts
@@ -158,6 +158,7 @@ function getRoomsByNewFormat(
   const section_name_format =
     /^([A-ZÅÄÖ0-9]{5,7}) ([HV]T[0-9]{2,4}) \(([^\)]+)\)/iu;
 
+  const regCodes: Set<string> = new Set();
   for (const section of sections) {
     const match = section.match(section_name_format);
     if (match) {
@@ -168,13 +169,16 @@ function getRoomsByNewFormat(
 
       // INVESTIGATE: Which section determines startTerm? Right now last wins
       link_meta_data.startTerm = convertStartTerm(startTerm);
-      link_meta_data.registrationCode = registrationCode;
+      regCodes.add(registrationCode);
     } else {
       // console.log(`Room ${canvas_data.id} Section "${section}" in "${canvas_data.name}"; no match.`)
     }
   }
 
   if (course_codes.size > 0) {
+    if (regCodes.size) {
+      link_meta_data.registrationCode = Array.from(regCodes).sort().join("/");
+    }
     return { course_codes, link_meta_data };
   }
 }


### PR DESCRIPTION
For course rooms that are combinded for multiple coures rounds, include all the relecant registration codes rather than one random.