### PR TITLE
Use data urls for svg icons.

### DIFF
--- a/kpm/kpm-frontend/src/Menu.scss
+++ b/kpm/kpm-frontend/src/Menu.scss
@@ -32,7 +32,7 @@
 
       &::after {
         content: "";
-        background: kthStyleUrl("/icons/arrow-expand-white.svg", no-repeat);
+        background: $data-arrow-expand-white-svg no-repeat;
         width: 0.3rem;
         height: 0.5rem;
         position: absolute;
@@ -47,7 +47,7 @@
       color: var(--kpmMenuHoverText);
       background-color: var(--kpmMenuHoverBg);
       &::after {
-        background: kthStyleUrl("/icons/arrow-expand-black.svg", no-repeat);
+        background: $data-arrow-expand-black-svg no-repeat;
       }
     }
     &.kpm-try span {
@@ -165,7 +165,7 @@
           color: var(--kpmMenuHoverText);
 
           &::after {
-            background: kthStyleUrl("/icons/arrow-expand-black.svg", no-repeat);
+            background: $data-arrow-expand-black-svg no-repeat;
           }
         }
       }
@@ -190,7 +190,7 @@
         height: 0.65rem;
         right: 0.5rem;
         transform: translate(-50%, -50%) rotate(90deg);
-        background: kthStyleUrl("/icons/arrow-expand-white.svg", no-repeat);
+        background: $data-arrow-expand-white-svg no-repeat;
       }
     }
 
@@ -233,7 +233,7 @@
           background-color: var(--kpmMenuBg);
 
           // &::after {
-          //   background: kthStyleUrl("/icons/arrow-expand-black.svg", no-repeat);
+          //   background: $data-arrow-expand-black-svg no-repeat;
           // }
         }
       }
@@ -243,7 +243,7 @@
         height: 1rem;
         transform: translate(-50%, -50%);
         right: 1rem;
-        background: kthStyleUrl("/icons/arrow-expand-black.svg", no-repeat);
+        background: $data-arrow-expand-black-svg no-repeat;
       }
     }
   }

--- a/kpm/kpm-frontend/src/_vars.scss
+++ b/kpm/kpm-frontend/src/_vars.scss
@@ -1,13 +1,8 @@
+@forward "kth-style/public/sass/variables/svg_data";
+
 // TODO: We need to go through these breakpoints,
 // also check headers on site for mobile pixel size
 $mblBreakpoint: "screen and (max-width: 430px)";
 $desktopBreakpoint: "screen and (min-width: 431px)";
 $desktopMediumBreakpoint: "screen and (min-width: 431px) and (max-width: 928px)";
 $desktopLargeBreakpoint: "screen and (min-width: 929px)";
-
-$prod: "https://app.kth.se/style/static/kth-style/img/kth-style";
-$ref: "https://app-r.referens.sys.kth.se/style/static/kth-style/img/kth-style";
-
-@function kthStyleUrl($path, $suffix: "") {
-  @return url($prod + $path) $suffix, url($ref + $path) $suffix;
-}

--- a/kpm/kpm-frontend/src/components/groups.scss
+++ b/kpm/kpm-frontend/src/components/groups.scss
@@ -73,7 +73,7 @@
 
   & > summary:first-of-type::after {
     content: "";
-    background: kthStyleUrl("/icons/arrow-expand-black.svg", no-repeat);
+    background: $data-arrow-expand-black-svg no-repeat;
     width: 0.3rem;
     height: 0.5rem;
     position: absolute;

--- a/kpm/kpm-frontend/src/components/menu.scss
+++ b/kpm/kpm-frontend/src/components/menu.scss
@@ -124,7 +124,7 @@
 
       &::before {
         content: "";
-        background: kthStyleUrl("/icons/arrow-expand-black.svg", no-repeat);
+        background: $data-arrow-expand-black-svg no-repeat;
         transform: rotate(180deg);
         width: 0.4rem;
         height: 0.65rem;


### PR DESCRIPTION
Use the `$data-something-svg` variables provided by kth-style rather than trying to load icons externally from the kth-style app.

This gets rid of the CSP error where we try to load ref urls in prod.

kmp-frontend already had a dependency to kth-style, so I only needed to use it.