### PR TITLE
Dropdown menu size fix

### DIFF
--- a/.proxyrc
+++ b/.proxyrc
@@ -1,0 +1,8 @@
+{
+  "/kpm/api": {
+    "target": "http://localhost:3000/",
+    "pathRewrite": {
+      "^/api": ""
+    }
+  }
+}

--- a/kpm/kpm-backend/src/widget.js.ts
+++ b/kpm/kpm-backend/src/widget.js.ts
@@ -11,7 +11,10 @@ const PROXY_HOST = process.env.PROXY_HOST || `//localhost:${PORT}`;
 const PROXY_PATH_PREFIX = process.env.PROXY_PATH_PREFIX || "/kpm";
 const publicUriBase = `${PROXY_HOST}${PROXY_PATH_PREFIX}`;
 
-const distProdProductionPath = "./kpm-frontend/distProd/production";
+const distProdProductionPath = path.join(
+  __dirname,
+  "../../kpm-frontend/distProd/production"
+);
 
 /**
  * Responds with the initial javascript file that holds the entire personal menu
@@ -95,7 +98,7 @@ function getLatestDistFileNames() {
 
 function getLatestDistFileNamesFromDisk() {
   const manifestJson = readFileSync(
-    path.join("..", distProdProductionPath, "manifest.json")
+    path.join(distProdProductionPath, "manifest.json")
   );
   return JSON.parse(manifestJson.toString()) as Record<
     string,
@@ -104,14 +107,11 @@ function getLatestDistFileNamesFromDisk() {
 }
 
 // Mount paths appear to be relative to project root
-export const widgetJsAssets = staticHandler(
-  path.join("..", distProdProductionPath),
-  {
-    immutable: true,
-    index: false,
-    maxAge: "180 days",
-  }
-);
+export const widgetJsAssets = staticHandler(distProdProductionPath, {
+  immutable: true,
+  index: false,
+  maxAge: "180 days",
+});
 
 export function previewHandler(req: Request, res: Response) {
   const { ext } = req.params;

--- a/kpm/kpm-frontend/src/components/groups.scss
+++ b/kpm/kpm-frontend/src/components/groups.scss
@@ -38,6 +38,7 @@
     left: 0;
     max-width: 95%;
     min-height: 200px; // Use a constant value in pixels, otherwise we have problems
+    max-height: calc(100vh - 20px); // Same as PADDING in groupsUtils.ts
     background-color: var(--kpmPaneBg);
     overflow-y: auto;
     box-shadow: 4px 4px 10px rgb(0 0 0 / 20%);

--- a/kpm/kpm-frontend/src/components/groupsUtils.ts
+++ b/kpm/kpm-frontend/src/components/groupsUtils.ts
@@ -149,7 +149,7 @@ export function useDropdownToggleListener(
  sure we don't hide it with the menubar. This looks wierd if we aren't in modal mode
  (default) but not worth pursuing a fix for now.
  */
-const PADDING = 10;
+const PADDING = 10; // This value is used in groups.scss, search for PADDING
 export function usePositionDropdown(
   detailsRef: RefObject<HTMLElement | null>,
   summaryRef: RefObject<HTMLElement | null>,
@@ -233,10 +233,19 @@ export function usePositionDropdown(
     }
 
     let deltaY; // may depend on actual height of dropdown
-    if (placeTop) {
+    if (spaceTop + spaceBottom < dropdownHeight + PADDING) {
+      // Not enough space on on either side, just center
+      // on page,
+      deltaY = PADDING;
+    } else if (placeTop) {
       deltaY = elTop - dropdownHeight;
     } else {
-      deltaY = elBottom;
+      if (spaceBottom < dropdownHeight + PADDING) {
+        // Move up to fit
+        deltaY = elBottom - dropdownHeight + spaceBottom - PADDING;
+      } else {
+        deltaY = elBottom;
+      }
     }
 
     // Nudge placement on X axis depending on available space


### PR DESCRIPTION
This solves an issue where teachers with small laptop screens couldn't see the full Cours Admin dropdown menu.