### PR TITLE
Check if session is still valid when computer is waking up from sleep

### DIFF
--- a/kpm/kpm-frontend/src/state/authState.ts
+++ b/kpm/kpm-frontend/src/state/authState.ts
@@ -96,11 +96,12 @@ setInterval(testExpiredSession, 15 * 60 * 1000);
 
 // Check session valid on wake up
 let lastTimeChecked = new Date().getTime();
+const checkIntervalMs = 2000;
 setInterval(function () {
   var currentTime = new Date().getTime();
-  if (currentTime > lastTimeChecked + 2000 * 2) {
+  if (currentTime > lastTimeChecked + checkIntervalMs * 2) {
     console.log("Computer woke up");
     testExpiredSession();
   }
   lastTimeChecked = currentTime;
-}, 2000);
+}, checkIntervalMs);

--- a/kpm/kpm-frontend/src/state/authState.ts
+++ b/kpm/kpm-frontend/src/state/authState.ts
@@ -80,8 +80,7 @@ export function initSessionCheck() {
   setTimeout(checkValidSession); // Once on startup, without delaying first paint
 }
 
-// Check if session is valid for at least 30 mins every 15 mins
-setInterval(() => {
+function testExpiredSession() {
   const user = authState.state("CurrentUser");
   const now = new Date().getTime();
   if (user.expires < now + 30 * 60 * 1000) {
@@ -90,4 +89,18 @@ setInterval(() => {
       value: undefined,
     });
   }
-}, 15 * 60 * 1000);
+}
+
+// Check if session is valid for at least 30 mins every 15 mins
+setInterval(testExpiredSession, 15 * 60 * 1000);
+
+// Check session valid on wake up
+let lastTimeChecked = new Date().getTime();
+setInterval(function () {
+  var currentTime = new Date().getTime();
+  if (currentTime > lastTimeChecked + 2000 * 2) {
+    console.log("Computer woke up");
+    testExpiredSession();
+  }
+  lastTimeChecked = currentTime;
+}, 2000);


### PR DESCRIPTION
There is no event fired on wake up so this is a known work around.

The issue we are solving is when someone awakes their computer after a nights sleep with a page open containing a logged KPM. https://edge.sys.kth.se/itsm/EfecteFrameset.do#/workspace/datacard/view/173050210