### PR TITLE
Trigger kpmLoaded-event after session has been checked

### DIFF
--- a/kpm/kpm-frontend/src/index.tsx
+++ b/kpm/kpm-frontend/src/index.tsx
@@ -4,29 +4,8 @@ import { App } from "./app";
 import { authState, initSessionCheck } from "./state/authState";
 import { TPubSubEvent } from "./state/PubSub";
 
-function sendKpmLoaded(authorized: boolean) {
-  document.dispatchEvent(
-    new CustomEvent("kpmLoaded", {
-      detail: {
-        authorized,
-        lang: window.__kpmSettings__?.["lang"] || "en",
-      },
-    })
-  );
-}
-
-function currentUserDidUpdate(event: TPubSubEvent<any>) {
-  if (event.name === "CurrentUser") {
-    sendKpmLoaded(!!event.value);
-  }
-}
-
 // Only mount menu in outermost frame
 if (window.frameElement === null) {
-  // Send global event kpmLoaded when the app is loaded and on auth state changes
-  authState.subscribe(currentUserDidUpdate);
-  sendKpmLoaded(!!authState.state("CurrentUser"));
-
   // Perform internal check to see if the user is logged in
   initSessionCheck();
 

--- a/kpm/kpm-frontend/src/state/authState.ts
+++ b/kpm/kpm-frontend/src/state/authState.ts
@@ -69,7 +69,7 @@ async function checkValidSession() {
 
   if (res.ok && json.user) {
     authState.send({ name: "CurrentUser", value: json.user });
-    sendKpmLoaded(!!json.user);
+    sendKpmLoaded(true);
     return;
   }
 

--- a/kpm/kpm-frontend/src/state/authState.ts
+++ b/kpm/kpm-frontend/src/state/authState.ts
@@ -69,10 +69,12 @@ async function checkValidSession() {
 
   if (res.ok && json.user) {
     authState.send({ name: "CurrentUser", value: json.user });
+    sendKpmLoaded(!!json.user);
     return;
   }
 
   authState.send({ name: "CurrentUser", value: undefined });
+  sendKpmLoaded(false);
 }
 
 export function initSessionCheck() {
@@ -91,3 +93,15 @@ setInterval(() => {
     });
   }
 }, 15 * 60 * 1000);
+
+function sendKpmLoaded(authorized: boolean) {
+  document.dispatchEvent(
+    new CustomEvent("kpmLoaded", {
+      detail: {
+        authorized,
+        lang: window.__kpmSettings__?.["lang"] || "en",
+        desc: "This event is fired when KPM is loaded and has checked SSO authorisation.",
+      },
+    })
+  );
+}

--- a/kpm/kpm-frontend/src/state/authState.ts
+++ b/kpm/kpm-frontend/src/state/authState.ts
@@ -95,13 +95,20 @@ setInterval(() => {
 }, 15 * 60 * 1000);
 
 function sendKpmLoaded(authorized: boolean) {
-  document.dispatchEvent(
-    new CustomEvent("kpmLoaded", {
-      detail: {
-        authorized,
-        lang: window.__kpmSettings__?.["lang"] || "en",
-        desc: "This event is fired when KPM is loaded and has checked SSO authorisation.",
-      },
-    })
-  );
+  // Only send this event when the page is visible
+  // to avoid multiple pages getting stuck on the
+  // login screen. Since checkValidSession() is
+  // called on visibilitychange, this event will
+  // be sent when the page is visible again.
+  if (!document.hidden) {
+    document.dispatchEvent(
+      new CustomEvent("kpmLoaded", {
+        detail: {
+          authorized,
+          lang: window.__kpmSettings__?.["lang"] || "en",
+          desc: "This event is fired when KPM is loaded and has checked SSO authorisation.",
+        },
+      })
+    );
+  }
 }


### PR DESCRIPTION
TODO: Discuss session length since KPM-session is 14 days and SSO is a lot shorter which could mean that other sites are logged out.

With multiple tabs refreshing, we will not trigger the kpmLoaded unless the tab is visible to avoid lots of redirects to the login form.