### PR TITLE
Add white bottom border to menu bar.

### DIFF
--- a/kpm/kpm-frontend/src/Menu.scss
+++ b/kpm/kpm-frontend/src/Menu.scss
@@ -6,6 +6,7 @@
   color: var(--kpmMenuText);
   width: 100%;
   flex-grow: 0;
+  border-bottom: solid 1px var(--kpmPaneBg);
 
   ul {
     display: flex;


### PR DESCRIPTION
Mainly needed at intra.kth.se, but also improves contrast as any text or images scrolls below the menu bar.

Requested in [KTH-INC-4308367](https://edge.sys.kth.se/itsm/EfecteFrameset.do#/workspace/datacard/view/173558211).