### PR TITLE
Not needed for menus, conflicts with overlay info boxes

### DIFF
--- a/kpm/kpm-frontend/src/stylesCanvas.scss
+++ b/kpm/kpm-frontend/src/stylesCanvas.scss
@@ -41,6 +41,17 @@ body.use-personal-menu .bcs__trigger {
   }
 }
 
+// Tooltips gets auto positioned by canvas js, but that puts them too low.
+// Normally there is no span elements directly under body, but that is
+// what canvas uses for tooltips, so here's hoping this is specific
+// enough.
+// There are classes on the elements involved, but all of them seem randomized.
+// WARNING: This is fragile, we are asuming that the prefix is stable between releases /jhsware
+// but this is probably the only way to target a subset of menus.
+body > span >span[class*="fOyUs_"] {
+  margin-top: calc(-1 * var(--kpm-bar-height));
+}
+
 // Provide space at top of <body> for kpm on pages where this isn't done by
 // the hosting page CSS. Specifically for iFrames in Canvas (SpeedGrader)
 body {

--- a/kpm/kpm-frontend/src/stylesCanvas.scss
+++ b/kpm/kpm-frontend/src/stylesCanvas.scss
@@ -41,15 +41,6 @@ body.use-personal-menu .bcs__trigger {
   }
 }
 
-// Tooltips gets auto positioned by canvas js, but that puts them too low.
-// Normally there is no span elements directly under body, but that is
-// what canvas uses for tooltips, so here's hoping this is specific
-// enough.
-// There are classes on the elements involved, but all of them seem randomized.
-body > span > span {
-  margin-top: calc(-1 * var(--kpm-bar-height));
-}
-
 // Provide space at top of <body> for kpm on pages where this isn't done by
 // the hosting page CSS. Specifically for iFrames in Canvas (SpeedGrader)
 body {


### PR DESCRIPTION
Canvas appear to have changed how menus are positioned so this has no effect, it does cause issues with overlays (such as accessability checker). Removing this. KTH-INC-4389439-Canvasfel