### PR TITLE
Make validators happy

### DIFF
--- a/kpm/kpm-frontend/src/Menu.scss
+++ b/kpm/kpm-frontend/src/Menu.scss
@@ -63,7 +63,8 @@
   }
 
   // Use for profile image and icons
-  $fullMenuHeight: calc(1.5em + 2 * var(--kpmPad));
+  // Default pad is mainly a type hint for validators
+  $fullMenuHeight: calc(1.5em + 2 * var(--kpmPad, 1em));
 
   .kpm-mobile-menu > a,
   .kpm-profile-item > a {
@@ -98,8 +99,9 @@
     a {
       display: flex;
       flex-grow: 1;
-      height: calc(0.75em + 2 * var(--kpmPad));
-      width: calc(0.75em + 2 * var(--kpmPad));
+      // Default pad is mainly a type hint for validators
+      height: calc(0.75em + 2 * var(--kpmPad, 1em));
+      width: calc(0.75em + 2 * var(--kpmPad, 1em));
       // height: $fullMenuHeight;
       // width: $fullMenuHeight;
       padding: calc(var(--kpmPad));


### PR DESCRIPTION
Validators and Pär Landberg complained about mismatching types for some uses of the `--kpmPad` css variable.  Add a default of 1em (which is a sane if large default, but should never actually be used, as the variable have a global value).