### PR TITLE
Read current site without using RegEx

### DIFF
--- a/kpm/kpm-backend/src/widget.js/notLoggedIn.js
+++ b/kpm/kpm-backend/src/widget.js/notLoggedIn.js
@@ -1,25 +1,26 @@
 (function (js, css, url) {
-  let RS = /^https?:\/\/(www\.)?kth.se\/(en\/)?student($|\/)/;
-  let RE = /^https?:\/\/(www\.)?kth.se($|\/)/;
-  let RI = /^https?:\/\/intra\.kth\.se/;
   let lang = document.documentElement.lang.startsWith("sv") ? "sv" : "en";
-  let links = {
-    external: {
+  let links = [
+    {
+      className: "external",
       href: { sv: "https://www.kth.se", en: "https://www.kth.se/en" },
       label: { en: "kth.se", sv: "kth.se" },
     },
-    student: {
+    {
+      className: "student-web",
       href: {
         sv: "https://www.kth.se/student",
         en: "https://www.kth.se/en/student",
       },
       label: { en: "Student web", sv: "Studentwebben" },
     },
-    intra: {
+    {
+      className: "intranet",
       href: { sv: "https://intra.kth.se", en: "https://intra.kth.se/en" },
       label: { en: "Intranet", sv: "Intranät" },
     },
-  };
+  ];
+
   let lbls = {
     w: { en: "Websites", sv: "Webbplatser" },
     l: { en: "Login", sv: "Logga in" },
@@ -48,40 +49,29 @@
   s.position = "fixed";
   s.height = "2.5rem";
 
-  const l = window.location.toString();
-  let current = "";
-
-  // Note: "student" must be checked before "external"
-  if (RS.test(l)) {
-    current = "student";
-  } else if (RI.test(l)) {
-    current = "intra";
-  } else if (RE.test(l)) {
-    current = "external";
-  }
-
-  let keys = ["external", "student", "intra"];
-
-  let lis = keys
-    .map((key) => {
-      let c = key === current ? "aria-current='true'" : "";
+  let header = document.querySelector(".kth-header");
+  let lis = links
+    .map((link) => {
+      let c = header?.classList.contains(link.className)
+        ? "aria-current='true'"
+        : "";
       let link = links[key];
 
       return `<li><a href=${link.href[lang]} ${c} class="kth-menu-item">${link.label[lang]}</a></li>`;
     })
     .join("");
 
-  let lis2 = keys
-    .map((key) => {
-      let link = links[key];
+  let lis2 = links
+    .map((link) => {
       return `<li><a href=${link.href[lang]}>${link.label[lang]}</a></li>`;
     })
     .join("");
 
   let login = `<a class="kth-menu-item kpm-login" href="${url}?nextUrl=${location.href}">${lbls.l[lang]}</a>`;
-
-  let currentLabel =
-    current === "" ? links.external.label[lang] : links[current].label[lang];
+  let currentItem = links.find((link) =>
+    header?.classList.contains(link.className)
+  );
+  let currentLabel = currentItem?.label[lang] ?? links[0].label[lang];
 
   root.innerHTML = `
     <div class="kth-kpm__container kpm-logged-out">

--- a/kpm/kpm-backend/src/widget.js/notLoggedIn.js
+++ b/kpm/kpm-backend/src/widget.js/notLoggedIn.js
@@ -55,7 +55,6 @@
       let c = header?.classList.contains(link.className)
         ? "aria-current='true'"
         : "";
-      let link = links[key];
 
       return `<li><a href=${link.href[lang]} ${c} class="kth-menu-item">${link.label[lang]}</a></li>`;
     })

--- a/kpm/kpm-frontend/src/components/entrances.tsx
+++ b/kpm/kpm-frontend/src/components/entrances.tsx
@@ -4,13 +4,13 @@ import "./entrances.scss";
 
 const labels = {
   external: "kth.se",
-  intra: i18n("shortcut.intranet"),
-  student: i18n("shortcut.studentweb"),
-};
+  intranet: i18n("shortcut.intranet"),
+  "student-web": i18n("shortcut.studentweb"),
+} as const;
 
 /** Get the current site */
-function getCurrentSite(): "external" | "intra" | "student" | undefined {
-  const SITES = ["external", "intra", "student"] as const;
+function getCurrentSite(): keyof typeof labels | undefined {
+  const SITES = ["external", "intranet", "student-web"] as const;
 
   return SITES.find((site) =>
     document.querySelector(".kth-header")?.classList.contains(site)
@@ -77,7 +77,7 @@ export function Entrances() {
             <a
               href={i18n("shortcut.studentweb.href")}
               className="kth-menu-item"
-              aria-current={currentSite === "student"}
+              aria-current={currentSite === "student-web"}
             >
               {i18n("shortcut.studentweb")}
             </a>
@@ -86,7 +86,7 @@ export function Entrances() {
             <a
               href={i18n("shortcut.intra.href")}
               className="kth-menu-item"
-              aria-current={currentSite === "intra"}
+              aria-current={currentSite === "intranet"}
             >
               {i18n("shortcut.intranet")}
             </a>

--- a/kpm/kpm-frontend/src/components/entrances.tsx
+++ b/kpm/kpm-frontend/src/components/entrances.tsx
@@ -2,10 +2,6 @@ import React from "react";
 import { i18n } from "../i18n/i18n";
 import "./entrances.scss";
 
-const STUDENT_REGEX2 = /^https?:\/\/(www\.)?kth.se\/(en\/)?student($|\/)/;
-const EXTERNAL_REGEX = /^https?:\/\/(www\.)?kth.se($|\/)/;
-const INTRA_REGEX = /^https?:\/\/intra\.kth\.se/;
-
 const labels = {
   external: "kth.se",
   intra: i18n("shortcut.intranet"),
@@ -14,15 +10,11 @@ const labels = {
 
 /** Get the current site */
 function getCurrentSite(): "external" | "intra" | "student" | undefined {
-  const currentPage = window.location.toString();
+  const SITES = ["external", "intra", "student"] as const;
 
-  if (STUDENT_REGEX2.test(currentPage)) {
-    return "student";
-  } else if (INTRA_REGEX.test(currentPage)) {
-    return "intra";
-  } else if (EXTERNAL_REGEX.test(currentPage)) {
-    return "external";
-  }
+  return SITES.find((site) =>
+    document.querySelector("kth-header")?.classList.contains(site)
+  );
 }
 
 /**

--- a/kpm/kpm-frontend/src/components/entrances.tsx
+++ b/kpm/kpm-frontend/src/components/entrances.tsx
@@ -13,7 +13,7 @@ function getCurrentSite(): "external" | "intra" | "student" | undefined {
   const SITES = ["external", "intra", "student"] as const;
 
   return SITES.find((site) =>
-    document.querySelector("kth-header")?.classList.contains(site)
+    document.querySelector(".kth-header")?.classList.contains(site)
   );
 }
 


### PR DESCRIPTION
This PR changes the way kpm guesses which is the current "site" (external, student-web or intranet).

Instead of looking at the URL, it looks if a given class is present in the header.