### PR TITLE
Add support for "stage" URLs

### DIFF
--- a/kpm/kpm-backend/src/index.ts
+++ b/kpm/kpm-backend/src/index.ts
@@ -55,6 +55,7 @@ class CorsError extends MutedOperationalError<TCorsError> {
 let corsWhitelist: string[] = [];
 if (IS_STAGE || IS_DEV) {
   corsWhitelist = [
+    "http://localhost:4321",
     "https://app-r.referens.sys.kth.se",
     "https://intra-r.referens.sys.kth.se",
     "https://kth.beta.instructure.com",

--- a/kpm/kpm-backend/src/index.ts
+++ b/kpm/kpm-backend/src/index.ts
@@ -55,7 +55,6 @@ class CorsError extends MutedOperationalError<TCorsError> {
 let corsWhitelist: string[] = [];
 if (IS_STAGE || IS_DEV) {
   corsWhitelist = [
-    "http://localhost:4321",
     "https://app-r.referens.sys.kth.se",
     "https://intra-r.referens.sys.kth.se",
     "https://kth.beta.instructure.com",

--- a/kpm/kpm-frontend/__test__/__snapshots__/test-panesGroups.spec.tsx.snap
+++ b/kpm/kpm-frontend/__test__/__snapshots__/test-panesGroups.spec.tsx.snap
@@ -28,19 +28,19 @@ exports[`<Groups /> Can be rendered 1`] = `
         className="kpm-modal-content-header-actions"
       >
         <a
-          href="https://www.kth.se/search/?entityFilter=social-group&filterLabel=Groups"
+          href="https://www-r.referens.sys.kth.se/search/?entityFilter=social-group&filterLabel=Groups"
           title="Search for interesting groups to follow"
         >
           Find groups
         </a>
         <a
-          href="https://www.kth.se/social/group-create/"
+          href="https://www-r.referens.sys.kth.se/social/group-create/"
         >
           Create new group
         </a>
         <a
           className="icon"
-          href="https://www.kth.se/social/home/settings/groups"
+          href="https://www-r.referens.sys.kth.se/social/home/settings/groups"
         >
           <svg
             height="1.2em"
@@ -122,19 +122,19 @@ exports[`<Groups /> Can be rendered with data and none starred 1`] = `
         className="kpm-modal-content-header-actions"
       >
         <a
-          href="https://www.kth.se/search/?entityFilter=social-group&filterLabel=Groups"
+          href="https://www-r.referens.sys.kth.se/search/?entityFilter=social-group&filterLabel=Groups"
           title="Search for interesting groups to follow"
         >
           Find groups
         </a>
         <a
-          href="https://www.kth.se/social/group-create/"
+          href="https://www-r.referens.sys.kth.se/social/group-create/"
         >
           Create new group
         </a>
         <a
           className="icon"
-          href="https://www.kth.se/social/home/settings/groups"
+          href="https://www-r.referens.sys.kth.se/social/home/settings/groups"
         >
           <svg
             height="1.2em"
@@ -256,19 +256,19 @@ exports[`<Groups /> Can be rendered with data and one starred 1`] = `
         className="kpm-modal-content-header-actions"
       >
         <a
-          href="https://www.kth.se/search/?entityFilter=social-group&filterLabel=Groups"
+          href="https://www-r.referens.sys.kth.se/search/?entityFilter=social-group&filterLabel=Groups"
           title="Search for interesting groups to follow"
         >
           Find groups
         </a>
         <a
-          href="https://www.kth.se/social/group-create/"
+          href="https://www-r.referens.sys.kth.se/social/group-create/"
         >
           Create new group
         </a>
         <a
           className="icon"
-          href="https://www.kth.se/social/home/settings/groups"
+          href="https://www-r.referens.sys.kth.se/social/home/settings/groups"
         >
           <svg
             height="1.2em"

--- a/kpm/kpm-frontend/__test__/__snapshots__/test-panesProfile.spec.tsx.snap
+++ b/kpm/kpm-frontend/__test__/__snapshots__/test-panesProfile.spec.tsx.snap
@@ -65,7 +65,7 @@ exports[`<Profile /> Can be rendered 1`] = `
         </li>
         <li>
           <a
-            href="https://www.kth.se/emailforward"
+            href="https://www-r.referens.sys.kth.se/emailforward"
           >
             Forward KTH email
           </a>
@@ -92,14 +92,14 @@ exports[`<Profile /> Can be rendered 1`] = `
       <ul>
         <li>
           <a
-            href="https://www.kth.se/social/home/settings/"
+            href="https://www-r.referens.sys.kth.se/social/home/settings/"
           >
             Subscriptions, my schedule
           </a>
         </li>
         <li>
           <a
-            href="https://www.kth.se/social/home/calendar/settings/"
+            href="https://www-r.referens.sys.kth.se/social/home/calendar/settings/"
           >
             Export My schedule (e.g. to your mobile phone)
           </a>

--- a/kpm/kpm-frontend/__test__/__snapshots__/test-panesServices.spec.tsx.snap
+++ b/kpm/kpm-frontend/__test__/__snapshots__/test-panesServices.spec.tsx.snap
@@ -28,14 +28,14 @@ exports[`<Services /> Can be rendered 1`] = `
         className="kpm-modal-content-header-actions"
       >
         <a
-          href="https://www.kth.se/social/group/feedback-fran-anvand/page/personliga-menyn/"
+          href="https://www-r.referens.sys.kth.se/social/group/feedback-fran-anvand/page/personliga-menyn/"
           title="Help / feedback for the personal menu"
         >
           Help / feedback
         </a>
         <a
           className="icon"
-          href="https://www.kth.se/social/servicelinks"
+          href="https://www-r.referens.sys.kth.se/social/servicelinks"
         >
           <svg
             height="1.2em"
@@ -172,14 +172,14 @@ exports[`<Services /> Can be rendered with data 1`] = `
         className="kpm-modal-content-header-actions"
       >
         <a
-          href="https://www.kth.se/social/group/feedback-fran-anvand/page/personliga-menyn/"
+          href="https://www-r.referens.sys.kth.se/social/group/feedback-fran-anvand/page/personliga-menyn/"
           title="Help / feedback for the personal menu"
         >
           Help / feedback
         </a>
         <a
           className="icon"
-          href="https://www.kth.se/social/servicelinks"
+          href="https://www-r.referens.sys.kth.se/social/servicelinks"
         >
           <svg
             height="1.2em"

--- a/kpm/kpm-frontend/src/Menu.tsx
+++ b/kpm/kpm-frontend/src/Menu.tsx
@@ -16,7 +16,7 @@ import { RefObject, useEffect, useRef, useState } from "react";
 import "./Menu.scss";
 import { useLogin } from "./components/login";
 import { useAuthState } from "./state/authState";
-import { createApiUri, createFilesUri } from "./panes/utils";
+import { createApiUri, prefixHost } from "./panes/utils";
 import { Entrances } from "./components/entrances";
 
 const KTH_MAIL_URI = "https://webmail.kth.se/";
@@ -84,7 +84,10 @@ export function Menu() {
                   className="kth-menu-item dropdown"
                 >
                   <img
-                    src={createFilesUri(`/thumbnail/${currentUser?.username}`)}
+                    src={prefixHost(
+                      "www",
+                      `/files/thumbnail/${currentUser?.username}`
+                    )}
                     alt=""
                     className="kpm-profile-image"
                   />
@@ -144,7 +147,10 @@ export function Menu() {
               <li className="kpm-profile-item kpm-mobile">
                 <ToggleNavLink to="profile" className={linkClassName}>
                   <img
-                    src={createFilesUri(`/thumbnail/${currentUser?.username}`)}
+                    src={prefixHost(
+                      "www",
+                      `/files/thumbnail/${currentUser?.username}`
+                    )}
                     alt=""
                     className="kpm-profile-image"
                   />
@@ -195,7 +201,10 @@ export function Menu() {
                   className={linkClassName}
                 >
                   <img
-                    src={createFilesUri(`/thumbnail/${currentUser?.username}`)}
+                    src={prefixHost(
+                      "www",
+                      `/files/thumbnail/${currentUser?.username}`
+                    )}
                     alt={i18n("Profile")}
                     className="kpm-profile-image"
                   />

--- a/kpm/kpm-frontend/src/panes/groups.tsx
+++ b/kpm/kpm-frontend/src/panes/groups.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { MenuPane, MenuPaneHeader } from "../components/menu";
 import { APIGroups } from "kpm-backend-interface";
-import { fetchApi, postApi, useDataFecther } from "./utils";
+import { fetchApi, postApi, useDataFecther, prefixHost } from "./utils";
 import {
   AuthError,
   EmptyPlaceholder,
@@ -122,14 +122,19 @@ export function Groups() {
       <MenuPaneHeader title={i18n("My Groups")}>
         <a
           title={i18n("Search for interesting groups to follow")}
-          href="https://www.kth.se/search/?entityFilter=social-group&filterLabel=Groups"
+          href={prefixHost(
+            "www",
+            "/search/?entityFilter=social-group&filterLabel=Groups"
+          )}
         >
           {i18n("Find groups")}
         </a>
-        <a href="https://www.kth.se/social/group-create/">
+        <a href={prefixHost("www", "/social/group-create/")}>
           {i18n("Create new group")}
         </a>
-        <IconSettings href="https://www.kth.se/social/home/settings/groups" />
+        <IconSettings
+          href={prefixHost("www", "/social/home/settings/groups")}
+        />
       </MenuPaneHeader>
       <TabFilter>
         <FilterOption<TFilter>

--- a/kpm/kpm-frontend/src/panes/profile.tsx
+++ b/kpm/kpm-frontend/src/panes/profile.tsx
@@ -1,11 +1,6 @@
 import * as React from "react";
 import { MenuPane, MenuPaneHeader } from "../components/menu";
-import {
-  createApiUri,
-  createFilesUri,
-  createProfilesUri,
-  postApi,
-} from "./utils";
+import { createApiUri, postApi, prefixHost } from "./utils";
 import { useAuthState } from "../state/authState";
 import { i18n, LANG } from "../i18n/i18n";
 import "./profile.scss";
@@ -40,17 +35,20 @@ export function Profile() {
           <li>
             <a
               className="kpm-profile-link"
-              href={createProfilesUri(`/${currentUser?.username}`)}
+              href={prefixHost("www", `/profile/${currentUser?.username}`)}
             >
               <img
-                src={createFilesUri(`/thumbnail/${currentUser?.username}`)}
+                src={prefixHost(
+                  "www",
+                  `/files/thumbnail/${currentUser?.username}`
+                )}
                 alt={i18n("Profile Image")}
               />
               {i18n("My Profile")}
             </a>
           </li>
           <li>
-            <a href="https://www.kth.se/emailforward">
+            <a href={prefixHost("www", "/emailforward")}>
               {i18n("Forward KTH email")}
             </a>
           </li>
@@ -66,12 +64,12 @@ export function Profile() {
         <h3 className="kpm-col-header">{i18n("My Settings")}</h3>
         <ul>
           <li>
-            <a href="https://www.kth.se/social/home/settings/">
+            <a href={prefixHost("www", "/social/home/settings/")}>
               {i18n("Subscriptions, my schedule")}
             </a>
           </li>
           <li>
-            <a href="https://www.kth.se/social/home/calendar/settings/">
+            <a href={prefixHost("www", "/social/home/calendar/settings/")}>
               {i18n("Export My schedule (e.g. to your mobile phone)")}
             </a>
           </li>

--- a/kpm/kpm-frontend/src/panes/programme.tsx
+++ b/kpm/kpm-frontend/src/panes/programme.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { MenuPane, MenuPaneHeader } from "../components/menu";
 import { APIProgrammes, TCanvasRoom } from "kpm-backend-interface";
-import { fetchApi, postApi, useDataFecther } from "./utils";
+import { fetchApi, postApi, prefixHost, useDataFecther } from "./utils";
 import {
   AuthError,
   EmptyPlaceholder,
@@ -74,11 +74,16 @@ export function Programme() {
       <MenuPaneHeader title={i18n("My Programmes")}>
         <a
           title="Help / feedback for the personal menu in connection with the transition to new Ladok"
-          href="https://www.kth.se/social/group/feedback-fran-anvand/page/personliga-menyn/"
+          href={prefixHost(
+            "www",
+            "/social/group/feedback-fran-anvand/page/personliga-menyn/"
+          )}
         >
           Help / feedback
         </a>
-        <IconSettings href="https://www.kth.se/social/home/settings/programmes" />
+        <IconSettings
+          href={prefixHost("www", "/social/home/settings/programmes")}
+        />
       </MenuPaneHeader>
       {loading && <LoadingPlaceholder />}
       {error && <ErrorMessage error={error} />}
@@ -114,7 +119,7 @@ function ProgramItem({ programCode, program }: TProgramItemProps) {
           {displayName}
         </a>
       </p>
-      <a href={`https://www.kth.se/student/kurser/program/${programCode}`}>
+      <a href={prefixHost("www", `/student/kurser/program/${programCode}`)}>
         {i18n("prog_syllabus")}
       </a>
     </section>

--- a/kpm/kpm-frontend/src/panes/services.tsx
+++ b/kpm/kpm-frontend/src/panes/services.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import { MenuPane, MenuPaneHeader } from "../components/menu";
 import { APIServices } from "kpm-backend-interface";
-import { fetchApi, useDataFecther } from "./utils";
+import { fetchApi, useDataFecther, prefixHost } from "./utils";
 import {
   AuthError,
   EmptyPlaceholder,
@@ -46,11 +46,14 @@ export function Services() {
       <MenuPaneHeader title={i18n("My Services")}>
         <a
           title={i18n("Help / feedback for the personal menu")}
-          href="https://www.kth.se/social/group/feedback-fran-anvand/page/personliga-menyn/"
+          href={prefixHost(
+            "www",
+            "/social/group/feedback-fran-anvand/page/personliga-menyn/"
+          )}
         >
           Help / feedback
         </a>
-        <IconSettings href="https://www.kth.se/social/servicelinks" />
+        <IconSettings href={prefixHost("www", "/social/servicelinks")} />
       </MenuPaneHeader>
       <Fragment>
         <div className="kpm-col">

--- a/kpm/kpm-frontend/src/panes/studies.tsx
+++ b/kpm/kpm-frontend/src/panes/studies.tsx
@@ -5,7 +5,7 @@ import {
   TStudiesCourseRound,
 } from "kpm-backend-interface";
 import { MenuPane } from "../components/menu";
-import { fetchApi, formatTerm, useDataFecther } from "./utils";
+import { fetchApi, formatTerm, prefixHost, useDataFecther } from "./utils";
 import { i18n } from "../i18n/i18n";
 
 import "./studies.scss";
@@ -216,9 +216,12 @@ function Course({ courseCode, course }: TCourseProps) {
 
 function getCourseInfoUrl(code: string, round?: TStudiesCourseRound) {
   if (round?.applicationCode !== undefined) {
-    return `https://www.kth.se/kurs-pm/${code}/${code}${round.year}${round.term}-${round.applicationCode}`;
+    return prefixHost(
+      "www",
+      `/kurs-pm/${code}/${code}${round.year}${round.term}-${round.applicationCode}`
+    );
   } else {
-    return `https://www.kth.se/kurs-pm/${code}/`;
+    return prefixHost("www", `/kurs-pm/${code}/`);
   }
 }
 

--- a/kpm/kpm-frontend/src/panes/teaching.tsx
+++ b/kpm/kpm-frontend/src/panes/teaching.tsx
@@ -11,7 +11,13 @@ import { MenuPane } from "../components/menu";
 import { DropdownMenuGroup, GroupItem } from "../components/groups";
 import { FilterOption, TabFilter } from "../components/filter";
 import { ExamRoomList } from "../components/courseComponents";
-import { fetchApi, postApi, formatTerm, useDataFecther } from "./utils";
+import {
+  fetchApi,
+  postApi,
+  formatTerm,
+  useDataFecther,
+  prefixHost,
+} from "./utils";
 import {
   AuthError,
   EmptyPlaceholder,
@@ -189,7 +195,7 @@ type TCourseProps = {
 
 function Course({ courseCode, course, setStar }: TCourseProps) {
   const courseName = i18n(course.title); // TODO: perhaps convert i18n to i18nHook that fetches language and returns i18n function
-  const aboutCourseUrl = `https://www.kth.se/kurs-pm/${courseCode}/om-kurs-pm`;
+  const aboutCourseUrl = prefixHost("www", `/kurs-pm/${courseCode}/om-kurs-pm`);
   // TODO: These should be changed to course rooms, check backend
   const {
     shortList = [],
@@ -458,48 +464,60 @@ function CourseAdminDropdown({
     >
       <GroupItem>
         <a
-          href={`https://www.kth.se/social/course/${courseCode}/editassistants/`}
+          href={prefixHost(
+            "www",
+            `/social/course/${courseCode}/editassistants/`
+          )}
         >
           {i18n("Administrera assistenter")}
         </a>
       </GroupItem>
       <GroupItem>
-        <a href={`https://www.kth.se/social/course/${courseCode}/subgroup/`}>
+        <a href={prefixHost("www", `/social/course/${courseCode}/subgroup/`)}>
           {i18n("Hantera Omgångar/grupper")}
         </a>
       </GroupItem>
       <GroupItem>
         <a
-          href={`https://app.kth.se/studentlistor/kurstillfallen/?courseCode=${courseCode}&term=${currentTerm}`}
+          href={prefixHost(
+            "app",
+            `/studentlistor/kurstillfallen/?courseCode=${courseCode}&term=${currentTerm}`
+          )}
         >
           {i18n("Kursdeltagare")}
         </a>
       </GroupItem>
       <GroupItem>
-        <a href={`https://app.kth.se/kopps/admin/courses/${courseCode}/`}>
+        <a href={prefixHost("app", `/kopps/admin/courses/${courseCode}/`)}>
           {i18n("Kursinformation i Kopps")}
         </a>
       </GroupItem>
       <GroupItem>
         <a
-          href={`https://app.kth.se/kursinfoadmin/kurser/kurs/edit/${courseCode}`}
+          href={prefixHost(
+            "app",
+            `/kursinfoadmin/kurser/kurs/edit/${courseCode}`
+          )}
         >
           {i18n("Redigera introduktion till kursen")}
         </a>
       </GroupItem>
       <GroupItem>
-        <a href={`https://app.kth.se/kursinfoadmin/kurs-pm-data/${courseCode}`}>
+        <a href={prefixHost("app", `kursinfoadmin/kurs-pm-data/${courseCode}`)}>
           {i18n("Skapa och publicera kurs-PM")}
         </a>
       </GroupItem>
       <GroupItem>
-        <a href={`https://www.kth.se/social/course/${courseCode}/survey/`}>
+        <a href={prefixHost("www", `/social/course/${courseCode}/survey/`)}>
           {i18n("Kursvärdering")}
         </a>
       </GroupItem>
       <GroupItem>
         <a
-          href={`https://app.kth.se/kursinfoadmin/kursutveckling/${courseCode}`}
+          href={prefixHost(
+            "app",
+            `/kursinfoadmin/kursutveckling/${courseCode}`
+          )}
         >
           {i18n("Publicera ny kursanalys")}
         </a>
@@ -512,13 +530,16 @@ function CourseAdminDropdown({
         </a>
       </GroupItem>
       <GroupItem>
-        <a href={`https://www.kth.se/social/course/${courseCode}/students/`}>
+        <a href={prefixHost("www", `/social/course/${courseCode}/students/`)}>
           {i18n("Studentgruppen / Prenumeranter")}
         </a>
       </GroupItem>
       <GroupItem>
         <a
-          href={`https://app.kth.se/aktivitetstillfallen/schema?courseCode=${courseCode}`}
+          href={prefixHost(
+            "app",
+            `/aktivitetstillfallen/schema?courseCode=${courseCode}`
+          )}
         >
           {i18n("Sök tentamen")}
         </a>

--- a/kpm/kpm-frontend/src/panes/teaching.tsx
+++ b/kpm/kpm-frontend/src/panes/teaching.tsx
@@ -503,7 +503,9 @@ function CourseAdminDropdown({
         </a>
       </GroupItem>
       <GroupItem>
-        <a href={prefixHost("app", `kursinfoadmin/kurs-pm-data/${courseCode}`)}>
+        <a
+          href={prefixHost("app", `/kursinfoadmin/kurs-pm-data/${courseCode}`)}
+        >
           {i18n("Skapa och publicera kurs-PM")}
         </a>
       </GroupItem>

--- a/kpm/kpm-frontend/src/panes/utils.ts
+++ b/kpm/kpm-frontend/src/panes/utils.ts
@@ -3,6 +3,31 @@ import { AuthError } from "../components/common";
 import { i18n, LANG } from "../i18n/i18n";
 import { authState } from "../state/authState";
 
+// Hosts. They are set up when compiling, not runtime
+const HOSTS = {
+  www: "https://www.kth.se",
+  app: "https://app.kth.se",
+  intra: "https://intra.kth.se",
+  canvas: "https://canvas.kth.se",
+};
+
+const REF_HOSTS: typeof HOSTS = {
+  www: "https://www-r.referens.sys.kth.se",
+  app: "https://app-r.referens.sys.kth.se",
+  intra: "https://intra-r.referens.sys.kth.se",
+  canvas: "https://kth.test.instructure.com",
+};
+
+export function prefixHost(key: keyof typeof HOSTS, path: string) {
+  if (
+    typeof window.__kpmPublicUriBase__ === "string" &&
+    window.__kpmPublicUriBase__.startsWith("https://app.kth.se/")
+  ) {
+    return HOSTS[key] + path;
+  }
+  return REF_HOSTS[key] + path;
+}
+
 declare global {
   interface Window {
     // NOTE: This global variable is set in widget.js.ts
@@ -16,24 +41,6 @@ export function createApiUri(path: string) {
   } else {
     return `/kpm${path}`;
   }
-}
-
-function getMainHost() {
-  if (
-    typeof window.__kpmPublicUriBase__ === "string" &&
-    window.__kpmPublicUriBase__.startsWith("https://app.kth.se/")
-  ) {
-    return `https://www.kth.se`;
-  }
-  return `https://www-r.referens.sys.kth.se`;
-}
-
-export function createFilesUri(path: string) {
-  return `${getMainHost()}/files${path}`;
-}
-
-export function createProfilesUri(path: string) {
-  return `${getMainHost()}/profile${path}`;
 }
 
 export function useDataFecther<T>(loaderFunc: () => Promise<T>): {


### PR DESCRIPTION
This PR generalizes the function `getMainHost` defined in `utils.ts` https://github.com/KTH/kpm/pull/228/files#diff-250f66c7f2d531bf7e4d12ee34da020d24a51afbff2765307ce229247197b29b and applies in all places where URLs are created