### PR TITLE
Fix: accessible mobile menu

### DIFF
--- a/kpm/kpm-frontend/__test__/__snapshots__/test.spec.tsx.snap
+++ b/kpm/kpm-frontend/__test__/__snapshots__/test.spec.tsx.snap
@@ -85,24 +85,24 @@ exports[`<App /> Can be rendered 1`] = `
     <nav
       className="kpm-menu"
     >
-      <ul>
-        <li
-          className="kpm-mobile-menu kpm-mobile"
+      <div
+        className="kpm-mobile-menu-opener"
+      >
+        <button
+          className="kth-menu-item dropdown"
+          onClick={[Function]}
         >
-          <a
-            className="kth-menu-item dropdown"
-            onClick={[Function]}
-          >
-            <img
-              alt=""
-              className="kpm-profile-image"
-              src="https://www-r.referens.sys.kth.se/files/thumbnail/jhsware"
-            />
-            <span>
-              Personal menu
-            </span>
-          </a>
-        </li>
+          <img
+            alt=""
+            className="kpm-profile-image"
+            src="https://www-r.referens.sys.kth.se/files/thumbnail/jhsware"
+          />
+          <span>
+            Personal menu
+          </span>
+        </button>
+      </div>
+      <ul>
         <li>
           <a
             className="kpm-menu-item kth-menu-item dropdown"

--- a/kpm/kpm-frontend/src/Menu.scss
+++ b/kpm/kpm-frontend/src/Menu.scss
@@ -42,7 +42,7 @@ $icon-kpm-notifications: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%
   box-shadow: 0 0.25rem 0.25rem 0 rgb(0 0 0 / 20%);
 }
 
-#kpm-6cf53 .kpm-mobile-menu {
+#kpm-6cf53 .kpm-mobile-menu-opener {
   display: none;
 }
 
@@ -116,7 +116,6 @@ $icon-kpm-notifications: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%
 }
 
 #kpm-6cf53 {
-  .kpm-mobile-menu.kpm-mobile,
   .kpm-profile-item.kpm-mobile,
   .kpm-mobile-logout.kpm-mobile {
     display: none;
@@ -136,7 +135,7 @@ $icon-kpm-notifications: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%
     display: none !important;
   }
 
-  #kpm-6cf53 .kpm-mobile-menu {
+  #kpm-6cf53 .kpm-mobile-menu-opener {
     display: flex;
     justify-content: flex-end;
   }

--- a/kpm/kpm-frontend/src/Menu.scss
+++ b/kpm/kpm-frontend/src/Menu.scss
@@ -150,12 +150,15 @@ $icon-kpm-notifications: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%
     }
 
     &.active > ul {
-      display: block;
+      visibility: visible;
+      opacity: 1;
     }
   }
 
   body #kpm-6cf53 .kpm-menu > ul {
-    display: none;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.2s;
     flex-direction: column;
 
     .kpm-profile-item {

--- a/kpm/kpm-frontend/src/Menu.scss
+++ b/kpm/kpm-frontend/src/Menu.scss
@@ -42,6 +42,10 @@ $icon-kpm-notifications: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%
   box-shadow: 0 0.25rem 0.25rem 0 rgb(0 0 0 / 20%);
 }
 
+#kpm-6cf53 .kpm-mobile-menu {
+  display: none;
+}
+
 #kpm-6cf53 .kpm-menu {
   pointer-events: all;
   background-color: var(--kpmMenuBg);
@@ -132,6 +136,11 @@ $icon-kpm-notifications: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%
     display: none !important;
   }
 
+  #kpm-6cf53 .kpm-mobile-menu {
+    display: flex;
+    justify-content: flex-end;
+  }
+
   body #kpm-6cf53 .kpm-menu {
     height: 2.5rem;
     overflow: hidden;
@@ -140,15 +149,15 @@ $icon-kpm-notifications: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%
     &.active {
       height: 100vh;
     }
+
+    &.active > ul {
+      display: block;
+    }
   }
 
   body #kpm-6cf53 .kpm-menu > ul {
+    display: none;
     flex-direction: column;
-
-    & > .kpm-mobile-menu {
-      display: inline-flex;
-      align-self: self-end;
-    }
 
     .kpm-profile-item {
       // Hide profile image

--- a/kpm/kpm-frontend/src/Menu.tsx
+++ b/kpm/kpm-frontend/src/Menu.tsx
@@ -74,7 +74,7 @@ export function Menu() {
           <MenuPaneBackdrop visible={hasMatch} onClose={() => navigate(-1)} />
           <Entrances />
           <nav ref={menuRef} className={cls}>
-            <div className="kpm-mobile-menu">
+            <div className="kpm-mobile-menu-opener">
               <button
                 onClick={(e: any) => {
                   e.preventDefault();

--- a/kpm/kpm-frontend/src/Menu.tsx
+++ b/kpm/kpm-frontend/src/Menu.tsx
@@ -74,27 +74,27 @@ export function Menu() {
           <MenuPaneBackdrop visible={hasMatch} onClose={() => navigate(-1)} />
           <Entrances />
           <nav ref={menuRef} className={cls}>
-            <ul>
-              <li className="kpm-mobile-menu kpm-mobile">
-                <a
-                  onClick={(e: any) => {
-                    e.preventDefault();
-                    setIsOpen(!isOpen);
-                  }}
-                  className="kth-menu-item dropdown"
-                >
-                  <img
-                    src={prefixHost(
-                      "www",
-                      `/files/thumbnail/${currentUser?.username}`
-                    )}
-                    alt=""
-                    className="kpm-profile-image"
-                  />
-                  <span>{i18n("Personal menu")}</span>
-                </a>
-              </li>
+            <div className="kpm-mobile-menu">
+              <button
+                onClick={(e: any) => {
+                  e.preventDefault();
+                  setIsOpen(!isOpen);
+                }}
+                className="kth-menu-item dropdown"
+              >
+                <img
+                  src={prefixHost(
+                    "www",
+                    `/files/thumbnail/${currentUser?.username}`
+                  )}
+                  alt=""
+                  className="kpm-profile-image"
+                />
+                <span>{i18n("Personal menu")}</span>
+              </button>
+            </div>
 
+            <ul>
               {hasStudies && (
                 <li>
                   <ToggleNavLink


### PR DESCRIPTION
This PR fixes these accessibility problems:

- The button to open the personal menu in mobile was not focusable.

  `<a>` tags without `href` are not focusable. This PR replaces the element with `<button>`

- The links for personal menu (Studies, Teaching...) were focusable even when they were not visible

  The links were "non-visible" by making the container shorter than the content, which meant that buttons were still focusable. This PR adds `display: none` to the container
