### PR TITLE
Bug in dropdown: visible even when not intended

### DIFF
--- a/kpm/kpm-frontend/src/app.scss
+++ b/kpm/kpm-frontend/src/app.scss
@@ -41,6 +41,7 @@
 // Global styling
 #kpm-6cf53 .kpm-modal {
   pointer-events: all;
+  overflow-x: hidden;
   max-width: 1200px;
   padding-inline: 2rem;
   padding-block: 1rem;

--- a/kpm/kpm-frontend/src/components/groupsUtils.ts
+++ b/kpm/kpm-frontend/src/components/groupsUtils.ts
@@ -176,8 +176,6 @@ export function usePositionDropdown(
       }
       callback({
         top: `${scrollOffset}px`,
-        visibility: "visible",
-        opacity: "1",
       });
       return (requestRef.current = requestAnimationFrame(calculate));
     }
@@ -278,8 +276,6 @@ export function usePositionDropdown(
 
     let newTransform: any = {
       transform: `translate(${deltaX}px, ${deltaY}px)`,
-      visibility: "visible",
-      opacity: "1",
     };
     callback(newTransform);
     requestRef.current = requestAnimationFrame(calculate);


### PR DESCRIPTION
This PR fixes the following problem:

- There is a React hook `useDropdownPosition` that calculates the position of a dropdown
- That hook sets more inline styles (visibility, opacity) which conflicts with CSS classes that controls visibility. Inline styles also have higher specificity than CSS

_There are other problems related with the dropdown, but those can be solved in upcoming PRs_