### PR TITLE
Ignore roles without round code

### DIFF
--- a/kpm/kpm-backend/src/api/studies.ts
+++ b/kpm/kpm-backend/src/api/studies.ts
@@ -78,6 +78,8 @@ export async function studiesApiHandler(
         // Skip roles that does not represent a course round
         if (role.year === undefined || role.term === undefined) continue;
 
+        if (role.round === undefined && role.round_code === undefined) continue;
+
         // Add rounds to course object
         const term = `${role.year}${role.term}`;
         mytermrounds[term] ??= [];


### PR DESCRIPTION
With this PR, UG groups that don't have a "omgångsnummer" (1 digit) or "kurstillfälleskod" (5 digits) are _not_ considered "course rounds", which can be problematic for courses that spans multiple terms. Hypothetical example:

The course "DD.1320" is held in terms "20212", "20221" and "20222" (3 terms). In this case, the student is a member of the following groups:

- `ladok.courses.DD.1320.registredade_20212.1` (has `.1` in the end, it is the course round)
- `ladok.courses.DD.1320.registrerade_20212`
- `ladok.courses.DD.1320.registrerade_20221`
- `ladok.courses.DD.1320.registrerade_20222`

The first group is the actual course round the student is registered. The other 3 do not represent any course round, there is no Canvas course room for them and should _not_ be considered by KPM as re-registration

