### PR TITLE
Fix/dropdown

### DIFF
--- a/kpm/kpm-frontend/src/components/groups.scss
+++ b/kpm/kpm-frontend/src/components/groups.scss
@@ -34,7 +34,10 @@
     z-index: 999;
     max-width: 95%;
     min-height: 200px; // Use a constant value in pixels, otherwise we have problems
-    max-height: calc(100vh - 20px); // Same as PADDING in groupsUtils.ts
+
+    // Same as PADDING in groupsUtils.ts
+    $padding-in-group-utils: 60px;
+    max-height: min(calc(90vh - $padding-in-group-utils), 40rem);
     background-color: var(--kpmPaneBg);
     overflow-y: auto;
     box-shadow: 4px 4px 10px rgb(0 0 0 / 20%);

--- a/kpm/kpm-frontend/src/components/groupsUtils.ts
+++ b/kpm/kpm-frontend/src/components/groupsUtils.ts
@@ -146,15 +146,15 @@ export function useDropdownToggleListener(
 /**
  Adjust size of dropdown to avoid overflow and switch side (vertical only) to allow
  best use of available screen realestate.
- 
+
  We do this continuosly on animation frame becuase there are lots of layout changes
  that can affect the placement and don't generate events.
- 
+
  Currently we aren't aware of the menubar so the popup needs to be layered on top to make
  sure we don't hide it with the menubar. This looks wierd if we aren't in modal mode
  (default) but not worth pursuing a fix for now.
  */
-const PADDING = 10; // This value is used in groups.scss, search for PADDING
+const PADDING = 60; // This value is used in groups.scss, search for PADDING
 export function usePositionDropdown(
   menuWrapperRef: RefObject<HTMLElement | null>,
   dropdownRef: RefObject<HTMLElement | null>,

--- a/kpm/kpm-frontend/src/components/menu.scss
+++ b/kpm/kpm-frontend/src/components/menu.scss
@@ -41,6 +41,7 @@
   // Leave som space to the sides of modal on desktop
   width: calc(100% - 4 * var(--kpmMargin));
   max-width: 80rem;
+  min-height: 40rem;
 
   // Styling
   padding: 0;


### PR DESCRIPTION
This PR fixes two problems with dropdowns:

- Dropdowns not visible when the modal is too small and the content of the dropdown is too big
- Too little padding around dropdowns when they are too big